### PR TITLE
Non unique state id support for Samza Runner 

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -391,7 +391,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.38.6'
+    project.version = '2.38.7'
 
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,8 +24,8 @@ offlineRepositoryRoot=offline-repository
 signing.gnupg.executable=gpg
 signing.gnupg.useLegacyGpg=true
 
-version=2.38.6
-sdk_version=2.38.6
+version=2.38.7
+sdk_version=2.38.7
 # WARNING! Many Beam modules use a custom Gradle plugin that overrides the
 # project version defined here in the `apply` function in
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.

--- a/runners/samza/build.gradle
+++ b/runners/samza/build.gradle
@@ -171,10 +171,6 @@ tasks.register("validatesRunner", Test) {
     excludeTestsMatching 'org.apache.beam.sdk.transforms.SplittableDoFnTest.testPairWithIndexWindowedTimestampedUnbounded'
     excludeTestsMatching 'org.apache.beam.sdk.transforms.SplittableDoFnTest.testOutputAfterCheckpointUnbounded'
   }
-  filter {
-    // Re-enable the test after Samza runner supports same state id across DoFn(s).
-    excludeTest('ParDoTest$StateTests', 'testValueStateSameId')
-  }
 }
 
 // Generates :runners:samza:runQuickstartJavaSamza

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaRunner.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaRunner.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.Set;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.construction.SplittableParDo;
 import org.apache.beam.runners.core.construction.renderer.PipelineDotRenderer;
@@ -34,6 +35,7 @@ import org.apache.beam.runners.samza.translation.PortableTranslationContext;
 import org.apache.beam.runners.samza.translation.SamzaPipelineTranslator;
 import org.apache.beam.runners.samza.translation.SamzaPortablePipelineTranslator;
 import org.apache.beam.runners.samza.translation.SamzaTransformOverrides;
+import org.apache.beam.runners.samza.translation.StateIdParser;
 import org.apache.beam.runners.samza.translation.TranslationContext;
 import org.apache.beam.runners.samza.util.PipelineJsonRenderer;
 import org.apache.beam.sdk.Pipeline;
@@ -146,9 +148,11 @@ public class SamzaRunner extends PipelineRunner<SamzaPipelineResult> {
     LOG.info("Beam pipeline JSON graph:\n{}", jsonGraph);
 
     final Map<PValue, String> idMap = PViewToIdMapper.buildIdMap(pipeline);
+    final Set<String> nonUniqueStateIds = StateIdParser.scan(pipeline);
     final ConfigBuilder configBuilder = new ConfigBuilder(options);
 
-    SamzaPipelineTranslator.createConfig(pipeline, options, idMap, configBuilder);
+    SamzaPipelineTranslator.createConfig(
+        pipeline, options, idMap, nonUniqueStateIds, configBuilder);
     configBuilder.put(BEAM_DOT_GRAPH, dotGraph);
     configBuilder.put(BEAM_JSON_GRAPH, jsonGraph);
 
@@ -168,7 +172,7 @@ public class SamzaRunner extends PipelineRunner<SamzaPipelineResult> {
           appDescriptor.withMetricsReporterFactories(reporterFactories);
 
           SamzaPipelineTranslator.translate(
-              pipeline, new TranslationContext(appDescriptor, idMap, options));
+              pipeline, new TranslationContext(appDescriptor, idMap, nonUniqueStateIds, options));
         };
 
     // perform a final round of validation for the pipeline options now that all configs are

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/DoFnOp.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/DoFnOp.java
@@ -127,6 +127,7 @@ public class DoFnOp<InT, FnOutT, OutT> implements Op<InT, OutT, Void> {
 
   private final DoFnSchemaInformation doFnSchemaInformation;
   private final Map<?, PCollectionView<?>> sideInputMapping;
+  private final Map<String, String> stateIdToStoreMapping;
 
   public DoFnOp(
       TupleTag<FnOutT> mainOutputTag,
@@ -148,7 +149,8 @@ public class DoFnOp<InT, FnOutT, OutT> implements Op<InT, OutT, Void> {
       JobInfo jobInfo,
       Map<String, TupleTag<?>> idToTupleTagMap,
       DoFnSchemaInformation doFnSchemaInformation,
-      Map<?, PCollectionView<?>> sideInputMapping) {
+      Map<?, PCollectionView<?>> sideInputMapping,
+      Map<String, String> stateIdToStoreMapping) {
     this.mainOutputTag = mainOutputTag;
     this.doFn = doFn;
     this.sideInputs = sideInputs;
@@ -171,6 +173,7 @@ public class DoFnOp<InT, FnOutT, OutT> implements Op<InT, OutT, Void> {
     this.bundleStateId = "_samza_bundle_" + transformId;
     this.doFnSchemaInformation = doFnSchemaInformation;
     this.sideInputMapping = sideInputMapping;
+    this.stateIdToStoreMapping = stateIdToStoreMapping;
   }
 
   @Override
@@ -260,6 +263,7 @@ public class DoFnOp<InT, FnOutT, OutT> implements Op<InT, OutT, Void> {
               outputCoders,
               doFnSchemaInformation,
               (Map<String, PCollectionView<?>>) sideInputMapping,
+              stateIdToStoreMapping,
               emitter,
               outputFutureCollector);
     }

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaDoFnRunners.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaDoFnRunners.java
@@ -52,8 +52,6 @@ import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
-import org.apache.beam.sdk.transforms.reflect.DoFnSignature;
-import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.util.WindowedValue;
@@ -91,15 +89,19 @@ public class SamzaDoFnRunners {
       Map<TupleTag<?>, Coder<?>> outputCoders,
       DoFnSchemaInformation doFnSchemaInformation,
       Map<String, PCollectionView<?>> sideInputMapping,
+      Map<String, String> stateIdToStoreIdMapping,
       OpEmitter emitter,
       FutureCollector futureCollector) {
     final KeyedInternals keyedInternals;
     final TimerInternals timerInternals;
     final StateInternals stateInternals;
-    final DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
     final SamzaStoreStateInternals.Factory<?> stateInternalsFactory =
         SamzaStoreStateInternals.createStateInternalsFactory(
-            transformId, keyCoder, context.getTaskContext(), pipelineOptions, signature);
+            transformId,
+            keyCoder,
+            context.getTaskContext(),
+            pipelineOptions,
+            stateIdToStoreIdMapping);
 
     final SamzaExecutionContext executionContext =
         (SamzaExecutionContext) context.getApplicationContainerContext();

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaStoreStateInternals.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaStoreStateInternals.java
@@ -26,14 +26,12 @@ import java.lang.ref.SoftReference;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -66,7 +64,6 @@ import org.apache.beam.sdk.state.WatermarkHoldState;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.CombineWithContext;
 import org.apache.beam.sdk.transforms.SerializableFunction;
-import org.apache.beam.sdk.transforms.reflect.DoFnSignature;
 import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
@@ -129,18 +126,7 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
    */
   static <K> Factory<K> createNonKeyedStateInternalsFactory(
       String id, TaskContext context, SamzaPipelineOptions pipelineOptions) {
-    return createStateInternalsFactory(id, null, context, pipelineOptions, Collections.emptySet());
-  }
-
-  static <K> Factory<K> createStateInternalsFactory(
-      String id,
-      Coder<K> keyCoder,
-      TaskContext context,
-      SamzaPipelineOptions pipelineOptions,
-      DoFnSignature signature) {
-
-    return createStateInternalsFactory(
-        id, keyCoder, context, pipelineOptions, signature.stateDeclarations().keySet());
+    return createStateInternalsFactory(id, null, context, pipelineOptions, Collections.emptyMap());
   }
 
   static <K> Factory<K> createStateInternalsFactory(
@@ -150,31 +136,35 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
       SamzaPipelineOptions pipelineOptions,
       ExecutableStage executableStage) {
 
-    Set<String> stateIds =
+    Map<String, String> stateIdToStoreMap =
         executableStage.getUserStates().stream()
-            .map(UserStateReference::localName)
-            .collect(Collectors.toSet());
+            .collect(
+                Collectors.toMap(UserStateReference::localName, UserStateReference::localName));
 
-    return createStateInternalsFactory(id, keyCoder, context, pipelineOptions, stateIds);
+    return createStateInternalsFactory(id, keyCoder, context, pipelineOptions, stateIdToStoreMap);
   }
 
   @SuppressWarnings("unchecked")
-  private static <K> Factory<K> createStateInternalsFactory(
+  static <K> Factory<K> createStateInternalsFactory(
       String id,
       @Nullable Coder<K> keyCoder,
       TaskContext context,
       SamzaPipelineOptions pipelineOptions,
-      Collection<String> stateIds) {
+      Map<String, String> stateIdToStoreMap) {
     final int batchGetSize = pipelineOptions.getStoreBatchGetSize();
     final Map<String, KeyValueStore<ByteArray, StateValue<?>>> stores = new HashMap<>();
     stores.put(BEAM_STORE, getBeamStore(context));
 
     final Coder<K> stateKeyCoder;
     if (keyCoder != null) {
-      stateIds.forEach(
-          stateId ->
-              stores.put(
-                  stateId, (KeyValueStore<ByteArray, StateValue<?>>) context.getStore(stateId)));
+      stateIdToStoreMap
+          .keySet()
+          .forEach(
+              stateId ->
+                  stores.put(
+                      stateId,
+                      (KeyValueStore<ByteArray, StateValue<?>>)
+                          context.getStore(stateIdToStoreMap.get(stateId))));
       stateKeyCoder = keyCoder;
     } else {
       stateKeyCoder = (Coder<K>) VoidCoder.of();

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/ConfigBuilder.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/ConfigBuilder.java
@@ -52,6 +52,7 @@ import org.apache.samza.job.yarn.YarnJobFactory;
 import org.apache.samza.runtime.LocalApplicationRunner;
 import org.apache.samza.runtime.RemoteApplicationRunner;
 import org.apache.samza.standalone.PassthroughJobCoordinatorFactory;
+import org.apache.samza.storage.kv.RocksDbKeyValueStorageEngineFactory;
 import org.apache.samza.zk.ZkJobCoordinatorFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -306,9 +307,7 @@ public class ConfigBuilder {
   static Map<String, String> createRocksDBStoreConfig(SamzaPipelineOptions options) {
     final ImmutableMap.Builder<String, String> configBuilder =
         ImmutableMap.<String, String>builder()
-            .put(
-                BEAM_STORE_FACTORY,
-                "org.apache.samza.storage.kv.RocksDbKeyValueStorageEngineFactory")
+            .put(BEAM_STORE_FACTORY, RocksDbKeyValueStorageEngineFactory.class.getName())
             .put("stores.beamStore.rocksdb.compression", "lz4");
 
     if (options.getStateDurable()) {

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/ConfigContext.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/ConfigContext.java
@@ -17,10 +17,10 @@
  */
 package org.apache.beam.runners.samza.translation;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.beam.runners.samza.SamzaPipelineOptions;
+import org.apache.beam.runners.samza.util.StoreIdGenerator;
 import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.runners.TransformHierarchy;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -35,12 +35,13 @@ public class ConfigContext {
   private final Map<PValue, String> idMap;
   private AppliedPTransform<?, ?, ?> currentTransform;
   private final SamzaPipelineOptions options;
-  private final Set<String> stateIds;
+  private final StoreIdGenerator storeIdGenerator;
 
-  public ConfigContext(Map<PValue, String> idMap, SamzaPipelineOptions options) {
+  public ConfigContext(
+      Map<PValue, String> idMap, Set<String> nonUniqueStateIds, SamzaPipelineOptions options) {
     this.idMap = idMap;
     this.options = options;
-    this.stateIds = new HashSet<>();
+    this.storeIdGenerator = new StoreIdGenerator(nonUniqueStateIds);
   }
 
   public void setCurrentTransform(AppliedPTransform<?, ?, ?> currentTransform) {
@@ -64,8 +65,8 @@ public class ConfigContext {
     return this.options;
   }
 
-  public boolean addStateId(String stateId) {
-    return stateIds.add(stateId);
+  public StoreIdGenerator getStoreIdGenerator() {
+    return storeIdGenerator;
   }
 
   private String getIdForPValue(PValue pvalue) {

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/ParDoBoundMultiTranslator.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/ParDoBoundMultiTranslator.java
@@ -72,6 +72,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterator
 import org.apache.samza.operators.MessageStream;
 import org.apache.samza.operators.functions.FlatMapFunction;
 import org.apache.samza.operators.functions.WatermarkFunction;
+import org.apache.samza.storage.kv.RocksDbKeyValueStorageEngineFactory;
 import org.joda.time.Instant;
 
 /**
@@ -161,6 +162,13 @@ class ParDoBoundMultiTranslator<InT, OutT>
     Map<String, PCollectionView<?>> sideInputMapping =
         ParDoTranslation.getSideInputMapping(ctx.getCurrentTransform());
 
+    final DoFnSignature signature = DoFnSignatures.getSignature(transform.getFn().getClass());
+    final Map<String, String> stateIdToStoreMapping = new HashMap<>();
+    for (String stateId : signature.stateDeclarations().keySet()) {
+      final String transformFullName = node.getEnclosingNode().getFullName();
+      final String storeId = ctx.getStoreIdGenerator().getId(stateId, transformFullName);
+      stateIdToStoreMapping.put(stateId, storeId);
+    }
     final DoFnOp<InT, OutT, RawUnionValue> op =
         new DoFnOp<>(
             transform.getMainOutputTag(),
@@ -182,7 +190,8 @@ class ParDoBoundMultiTranslator<InT, OutT>
             null,
             Collections.emptyMap(),
             doFnSchemaInformation,
-            sideInputMapping);
+            sideInputMapping,
+            stateIdToStoreMapping);
 
     final MessageStream<OpMessage<InT>> mergedStreams;
     if (sideInputStreams.isEmpty()) {
@@ -333,7 +342,8 @@ class ParDoBoundMultiTranslator<InT, OutT>
             ctx.getJobInfo(),
             idToTupleTagMap,
             doFnSchemaInformation,
-            sideInputMapping);
+            sideInputMapping,
+            Collections.emptyMap());
 
     final MessageStream<OpMessage<InT>> mergedStreams;
     if (sideInputStreams.isEmpty()) {
@@ -376,18 +386,11 @@ class ParDoBoundMultiTranslator<InT, OutT>
 
     if (signature.usesState()) {
       // set up user state configs
-      for (DoFnSignature.StateDeclaration state : signature.stateDeclarations().values()) {
-        final String storeId = state.id();
-
-        // TODO: remove validation after we support same state id in different ParDo.
-        if (!ctx.addStateId(storeId)) {
-          throw new IllegalStateException(
-              "Duplicate StateId " + storeId + " found in multiple ParDo.");
-        }
-
+      for (String stateId : signature.stateDeclarations().keySet()) {
+        final String transformFullName = node.getEnclosingNode().getFullName();
+        final String storeId = ctx.getStoreIdGenerator().getId(stateId, transformFullName);
         config.put(
-            "stores." + storeId + ".factory",
-            "org.apache.samza.storage.kv.RocksDbKeyValueStorageEngineFactory");
+            "stores." + storeId + ".factory", RocksDbKeyValueStorageEngineFactory.class.getName());
         config.put("stores." + storeId + ".key.serde", "byteArraySerde");
         config.put("stores." + storeId + ".msg.serde", "stateValueSerde");
         config.put("stores." + storeId + ".rocksdb.compression", "lz4");
@@ -430,8 +433,7 @@ class ParDoBoundMultiTranslator<InT, OutT>
       final String storeId = stateId.getLocalName();
 
       config.put(
-          "stores." + storeId + ".factory",
-          "org.apache.samza.storage.kv.RocksDbKeyValueStorageEngineFactory");
+          "stores." + storeId + ".factory", RocksDbKeyValueStorageEngineFactory.class.getName());
       config.put("stores." + storeId + ".key.serde", "byteArraySerde");
       config.put("stores." + storeId + ".msg.serde", "stateValueSerde");
       config.put("stores." + storeId + ".rocksdb.compression", "lz4");

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/PortableTranslationContext.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/PortableTranslationContext.java
@@ -50,7 +50,7 @@ public class PortableTranslationContext extends TranslationContext {
 
   public PortableTranslationContext(
       StreamApplicationDescriptor appDescriptor, SamzaPipelineOptions options, JobInfo jobInfo) {
-    super(appDescriptor, Collections.emptyMap(), options);
+    super(appDescriptor, Collections.emptyMap(), Collections.emptySet(), options);
     this.jobInfo = jobInfo;
   }
 

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/SamzaPipelineTranslator.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/SamzaPipelineTranslator.java
@@ -23,6 +23,7 @@ import com.google.auto.service.AutoService;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.Set;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
 import org.apache.beam.runners.core.construction.TransformPayloadTranslatorRegistrar;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
@@ -78,8 +79,9 @@ public class SamzaPipelineTranslator {
       Pipeline pipeline,
       SamzaPipelineOptions options,
       Map<PValue, String> idMap,
+      Set<String> nonUniqueStateIds,
       ConfigBuilder configBuilder) {
-    final ConfigContext ctx = new ConfigContext(idMap, options);
+    final ConfigContext ctx = new ConfigContext(idMap, nonUniqueStateIds, options);
 
     final TransformVisitorFn configFn =
         new TransformVisitorFn() {

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/StateIdParser.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/StateIdParser.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.samza.translation;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.beam.runners.samza.util.StateUtils;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.runners.TransformHierarchy;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.reflect.DoFnSignature;
+import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
+
+/**
+ * This class identifies the set of non-unique state ids by scanning the BEAM {@link Pipeline} with
+ * a topological traversal.
+ */
+@SuppressWarnings({
+  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
+public class StateIdParser extends Pipeline.PipelineVisitor.Defaults {
+  private final Set<String> nonUniqueStateIds = new HashSet<>();
+  private final Set<String> usedStateIds = new HashSet<>();
+
+  public static Set<String> scan(Pipeline pipeline) {
+    final StateIdParser parser = new StateIdParser();
+    pipeline.traverseTopologically(parser);
+    return parser.getNonUniqueStateIds();
+  }
+
+  private StateIdParser() {}
+
+  @Override
+  public void visitPrimitiveTransform(TransformHierarchy.Node node) {
+    if (node.getTransform() instanceof ParDo.MultiOutput) {
+      final DoFn<?, ?> doFn = ((ParDo.MultiOutput) node.getTransform()).getFn();
+      if (StateUtils.isStateful(doFn)) {
+        final DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
+        for (String stateId : signature.stateDeclarations().keySet()) {
+          if (!usedStateIds.add(stateId)) {
+            nonUniqueStateIds.add(stateId);
+          }
+        }
+      }
+    }
+  }
+
+  public Set<String> getNonUniqueStateIds() {
+    return Collections.unmodifiableSet(nonUniqueStateIds);
+  }
+}

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/TranslationContext.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/TranslationContext.java
@@ -30,6 +30,7 @@ import org.apache.beam.runners.core.construction.TransformInputs;
 import org.apache.beam.runners.samza.SamzaPipelineOptions;
 import org.apache.beam.runners.samza.runtime.OpMessage;
 import org.apache.beam.runners.samza.util.HashIdGenerator;
+import org.apache.beam.runners.samza.util.StoreIdGenerator;
 import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -85,16 +86,19 @@ public class TranslationContext {
   private final Map<String, Table> registeredTables = new HashMap<>();
   private final SamzaPipelineOptions options;
   private final HashIdGenerator idGenerator = new HashIdGenerator();
+  private final StoreIdGenerator storeIdGenerator;
 
   private AppliedPTransform<?, ?, ?> currentTransform;
 
   public TranslationContext(
       StreamApplicationDescriptor appDescriptor,
       Map<PValue, String> idMap,
+      Set<String> nonUniqueStateIds,
       SamzaPipelineOptions options) {
     this.appDescriptor = appDescriptor;
     this.idMap = idMap;
     this.options = options;
+    this.storeIdGenerator = new StoreIdGenerator(nonUniqueStateIds);
   }
 
   public <OutT> void registerInputMessageStream(
@@ -247,6 +251,10 @@ public class TranslationContext {
 
   public String getTransformId() {
     return idGenerator.getId(getTransformFullName());
+  }
+
+  public StoreIdGenerator getStoreIdGenerator() {
+    return storeIdGenerator;
   }
 
   /** The dummy stream created will only be used in Beam tests. */

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/util/SamzaPipelineTranslatorUtils.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/util/SamzaPipelineTranslatorUtils.java
@@ -46,8 +46,8 @@ public final class SamzaPipelineTranslatorUtils {
   /**
    * Escape the non-alphabet chars in the name so we can create a physical stream out of it.
    *
-   * <p>This escape will replace ".", "(" and "/" as "-", and then remove all the other
-   * non-alphabetic characters.
+   * <p>This escape will replace any non-alphanumeric characters other than "-" and "_" with "_"
+   * including whitespace.
    */
   public static String escape(String name) {
     return name.replaceFirst(".*:([a-zA-Z#0-9]+).*", "$1").replaceAll("[^A-Za-z0-9_-]", "_");

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/util/StoreIdGenerator.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/util/StoreIdGenerator.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.samza.util;
+
+import java.util.Set;
+
+/**
+ * This class encapsulates the logic to generate unique store id. For unique state ids across the
+ * Beam pipeline, store id is the same as the state id. For non-unique state ids, join the state id
+ * with an escaped transform name to generate a unique store id.
+ */
+public class StoreIdGenerator {
+
+  private final Set<String> nonUniqueStateIds;
+
+  public StoreIdGenerator(Set<String> nonUniqueStateId) {
+    this.nonUniqueStateIds = nonUniqueStateId;
+  }
+
+  public String getId(String stateId, String transformFullName) {
+    String storeId = stateId;
+    if (nonUniqueStateIds.contains(stateId)) {
+      final String escapedName = SamzaPipelineTranslatorUtils.escape(transformFullName);
+      storeId = toUniqueStoreId(stateId, escapedName);
+    }
+    return storeId;
+  }
+
+  /** Join state id and escaped PTransform name to uniquify store id. */
+  private static String toUniqueStoreId(String stateId, String escapedPTransformName) {
+    return String.join("-", stateId, escapedPTransformName);
+  }
+}

--- a/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/SamzaStoreStateInternalsTest.java
+++ b/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/SamzaStoreStateInternalsTest.java
@@ -50,6 +50,7 @@ import org.apache.beam.sdk.state.ReadableState;
 import org.apache.beam.sdk.state.SetState;
 import org.apache.beam.sdk.state.StateSpec;
 import org.apache.beam.sdk.state.StateSpecs;
+import org.apache.beam.sdk.state.ValueState;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
@@ -58,6 +59,7 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterators;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
@@ -190,6 +192,106 @@ public class SamzaStoreStateInternalsTest implements Serializable {
 
     PAssert.that(output).containsInAnyOrder(Sets.newHashSet(97, 42, 12));
 
+    pipeline.run();
+  }
+
+  @Test
+  public void testValueStateSameIdAcrossParDo() {
+    final String stateId = "foo";
+
+    DoFn<KV<String, Integer>, KV<String, Integer>> fn =
+        new DoFn<KV<String, Integer>, KV<String, Integer>>() {
+
+          @StateId(stateId)
+          private final StateSpec<ValueState<Integer>> intState =
+              StateSpecs.value(VarIntCoder.of());
+
+          @ProcessElement
+          public void processElement(
+              @StateId(stateId) ValueState<Integer> state, OutputReceiver<KV<String, Integer>> r) {
+            Integer currentValue = MoreObjects.firstNonNull(state.read(), 0);
+            r.output(KV.of("sizzle", currentValue));
+            state.write(currentValue + 1);
+          }
+        };
+
+    DoFn<KV<String, Integer>, Integer> fn2 =
+        new DoFn<KV<String, Integer>, Integer>() {
+
+          @StateId(stateId)
+          private final StateSpec<ValueState<Integer>> intState =
+              StateSpecs.value(VarIntCoder.of());
+
+          @ProcessElement
+          public void processElement(
+              @StateId(stateId) ValueState<Integer> state, OutputReceiver<Integer> r) {
+            Integer currentValue = MoreObjects.firstNonNull(state.read(), 13);
+            r.output(currentValue);
+            state.write(currentValue + 13);
+          }
+        };
+
+    PCollection<KV<String, Integer>> intermediate =
+        pipeline
+            .apply(Create.of(KV.of("hello", 42), KV.of("hello", 97), KV.of("hello", 84)))
+            .apply("First stateful ParDo", ParDo.of(fn));
+
+    PCollection<Integer> output = intermediate.apply("Second stateful ParDo", ParDo.of(fn2));
+
+    PAssert.that(intermediate)
+        .containsInAnyOrder(KV.of("sizzle", 0), KV.of("sizzle", 1), KV.of("sizzle", 2));
+    PAssert.that(output).containsInAnyOrder(13, 26, 39);
+    pipeline.run();
+  }
+
+  @Test
+  public void testValueStateSameIdAcrossParDoWithSameName() {
+    final String stateId = "foo";
+
+    DoFn<KV<String, Integer>, KV<String, Integer>> fn =
+        new DoFn<KV<String, Integer>, KV<String, Integer>>() {
+
+          @StateId(stateId)
+          private final StateSpec<ValueState<Integer>> intState =
+              StateSpecs.value(VarIntCoder.of());
+
+          @ProcessElement
+          public void processElement(
+              @StateId(stateId) ValueState<Integer> state, OutputReceiver<KV<String, Integer>> r) {
+            Integer currentValue = MoreObjects.firstNonNull(state.read(), 0);
+            r.output(KV.of("hello", currentValue));
+            state.write(currentValue + 1);
+          }
+        };
+
+    DoFn<KV<String, Integer>, Integer> fn2 =
+        new DoFn<KV<String, Integer>, Integer>() {
+
+          @StateId(stateId)
+          private final StateSpec<ValueState<Integer>> intState =
+              StateSpecs.value(VarIntCoder.of());
+
+          @ProcessElement
+          public void processElement(
+              @StateId(stateId) ValueState<Integer> state, OutputReceiver<Integer> r) {
+            Integer currentValue = MoreObjects.firstNonNull(state.read(), 13);
+            r.output(currentValue);
+            state.write(currentValue + 13);
+          }
+        };
+
+    PCollection<KV<String, Integer>> intermediate =
+        pipeline
+            .apply(Create.of(KV.of("hello", 42), KV.of("hello", 97), KV.of("hello", 84)))
+            .apply("Stateful ParDo with Same Name", ParDo.of(fn));
+
+    PCollection<Integer> output =
+        intermediate.apply("Stateful ParDo with Same Name", ParDo.of(fn2));
+
+    PAssert.that(intermediate)
+        .containsInAnyOrder(KV.of("hello", 0), KV.of("hello", 1), KV.of("hello", 2));
+
+    PAssert.that(output).containsInAnyOrder(13, 26, 39);
     pipeline.run();
   }
 

--- a/runners/samza/src/test/java/org/apache/beam/runners/samza/translation/ConfigGeneratorTest.java
+++ b/runners/samza/src/test/java/org/apache/beam/runners/samza/translation/ConfigGeneratorTest.java
@@ -19,11 +19,11 @@ package org.apache.beam.runners.samza.translation;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.beam.runners.samza.SamzaExecutionEnvironment;
 import org.apache.beam.runners.samza.SamzaPipelineOptions;
 import org.apache.beam.runners.samza.SamzaRunner;
@@ -73,8 +73,10 @@ public class ConfigGeneratorTest {
     pipeline.replaceAll(SamzaTransformOverrides.getDefaultOverrides());
 
     final Map<PValue, String> idMap = PViewToIdMapper.buildIdMap(pipeline);
+    final Set<String> nonUniqueStateIds = StateIdParser.scan(pipeline);
     final ConfigBuilder configBuilder = new ConfigBuilder(options);
-    SamzaPipelineTranslator.createConfig(pipeline, options, idMap, configBuilder);
+    SamzaPipelineTranslator.createConfig(
+        pipeline, options, idMap, nonUniqueStateIds, configBuilder);
     final Config config = configBuilder.build();
 
     assertEquals(
@@ -85,7 +87,8 @@ public class ConfigGeneratorTest {
     assertNull(config.get("stores.beamStore.changelog"));
 
     options.setStateDurable(true);
-    SamzaPipelineTranslator.createConfig(pipeline, options, idMap, configBuilder);
+    SamzaPipelineTranslator.createConfig(
+        pipeline, options, idMap, nonUniqueStateIds, configBuilder);
     final Config config2 = configBuilder.build();
     assertEquals(
         "TestStoreConfig-1-beamStore-changelog", config2.get("stores.beamStore.changelog"));
@@ -103,8 +106,10 @@ public class ConfigGeneratorTest {
     pipeline.replaceAll(SamzaTransformOverrides.getDefaultOverrides());
 
     final Map<PValue, String> idMap = PViewToIdMapper.buildIdMap(pipeline);
+    final Set<String> nonUniqueStateIds = StateIdParser.scan(pipeline);
     final ConfigBuilder configBuilder = new ConfigBuilder(options);
-    SamzaPipelineTranslator.createConfig(pipeline, options, idMap, configBuilder);
+    SamzaPipelineTranslator.createConfig(
+        pipeline, options, idMap, nonUniqueStateIds, configBuilder);
     final Config config = configBuilder.build();
 
     assertEquals(
@@ -115,7 +120,8 @@ public class ConfigGeneratorTest {
     assertNull(config.get("stores.beamStore.changelog"));
 
     options.setStateDurable(true);
-    SamzaPipelineTranslator.createConfig(pipeline, options, idMap, configBuilder);
+    SamzaPipelineTranslator.createConfig(
+        pipeline, options, idMap, nonUniqueStateIds, configBuilder);
     final Config config2 = configBuilder.build();
     // For stateless jobs, ignore state durable pipeline option.
     assertNull(config2.get("stores.beamStore.changelog"));
@@ -134,8 +140,10 @@ public class ConfigGeneratorTest {
     pipeline.replaceAll(SamzaTransformOverrides.getDefaultOverrides());
 
     final Map<PValue, String> idMap = PViewToIdMapper.buildIdMap(pipeline);
+    final Set<String> nonUniqueStateIds = StateIdParser.scan(pipeline);
     final ConfigBuilder configBuilder = new ConfigBuilder(options);
-    SamzaPipelineTranslator.createConfig(pipeline, options, idMap, configBuilder);
+    SamzaPipelineTranslator.createConfig(
+        pipeline, options, idMap, nonUniqueStateIds, configBuilder);
     final Config config = configBuilder.build();
 
     assertTrue(
@@ -162,8 +170,10 @@ public class ConfigGeneratorTest {
     pipeline.replaceAll(SamzaTransformOverrides.getDefaultOverrides());
 
     final Map<PValue, String> idMap = PViewToIdMapper.buildIdMap(pipeline);
+    final Set<String> nonUniqueStateIds = StateIdParser.scan(pipeline);
     final ConfigBuilder configBuilder = new ConfigBuilder(options);
-    SamzaPipelineTranslator.createConfig(pipeline, options, idMap, configBuilder);
+    SamzaPipelineTranslator.createConfig(
+        pipeline, options, idMap, nonUniqueStateIds, configBuilder);
     try {
       Config config = configBuilder.build();
       assertEquals(config.get(APP_RUNNER_CLASS), RemoteApplicationRunner.class.getName());
@@ -192,8 +202,10 @@ public class ConfigGeneratorTest {
     pipeline.replaceAll(SamzaTransformOverrides.getDefaultOverrides());
 
     final Map<PValue, String> idMap = PViewToIdMapper.buildIdMap(pipeline);
+    final Set<String> nonUniqueStateIds = StateIdParser.scan(pipeline);
     final ConfigBuilder configBuilder = new ConfigBuilder(options);
-    SamzaPipelineTranslator.createConfig(pipeline, options, idMap, configBuilder);
+    SamzaPipelineTranslator.createConfig(
+        pipeline, options, idMap, nonUniqueStateIds, configBuilder);
     try {
       Config config = configBuilder.build();
       assertEquals(config.get(APP_RUNNER_CLASS), LocalApplicationRunner.class.getName());
@@ -233,8 +245,10 @@ public class ConfigGeneratorTest {
                 }));
 
     final Map<PValue, String> idMap = PViewToIdMapper.buildIdMap(pipeline);
+    final Set<String> nonUniqueStateIds = StateIdParser.scan(pipeline);
     final ConfigBuilder configBuilder = new ConfigBuilder(options);
-    SamzaPipelineTranslator.createConfig(pipeline, options, idMap, configBuilder);
+    SamzaPipelineTranslator.createConfig(
+        pipeline, options, idMap, nonUniqueStateIds, configBuilder);
     final Config config = configBuilder.build();
 
     assertEquals(
@@ -245,14 +259,15 @@ public class ConfigGeneratorTest {
     assertNull(config.get("stores.testState.changelog"));
 
     options.setStateDurable(true);
-    SamzaPipelineTranslator.createConfig(pipeline, options, idMap, configBuilder);
+    SamzaPipelineTranslator.createConfig(
+        pipeline, options, idMap, nonUniqueStateIds, configBuilder);
     final Config config2 = configBuilder.build();
     assertEquals(
         "TestStoreConfig-1-testState-changelog", config2.get("stores.testState.changelog"));
   }
 
   @Test
-  public void testDuplicateStateIdConfig() {
+  public void testUserStoreConfigSameStateIdAcrossParDo() {
     SamzaPipelineOptions options = PipelineOptionsFactory.create().as(SamzaPipelineOptions.class);
     options.setJobName("TestStoreConfig");
     options.setRunner(SamzaRunner.class);
@@ -262,6 +277,7 @@ public class ConfigGeneratorTest {
         .apply(
             Create.empty(TypeDescriptors.kvs(TypeDescriptors.strings(), TypeDescriptors.strings())))
         .apply(
+            "First stateful ParDo",
             ParDo.of(
                 new DoFn<KV<String, String>, KV<String, String>>() {
                   private static final String testState = "testState";
@@ -276,6 +292,7 @@ public class ConfigGeneratorTest {
                   }
                 }))
         .apply(
+            "Second stateful ParDo",
             ParDo.of(
                 new DoFn<KV<String, String>, Void>() {
                   private static final String testState = "testState";
@@ -289,10 +306,111 @@ public class ConfigGeneratorTest {
                 }));
 
     final Map<PValue, String> idMap = PViewToIdMapper.buildIdMap(pipeline);
+    final Set<String> nonUniqueStateIds = StateIdParser.scan(pipeline);
     final ConfigBuilder configBuilder = new ConfigBuilder(options);
+    SamzaPipelineTranslator.createConfig(
+        pipeline, options, idMap, nonUniqueStateIds, configBuilder);
+    final Config config = configBuilder.build();
 
-    assertThrows(
-        IllegalStateException.class,
-        () -> SamzaPipelineTranslator.createConfig(pipeline, options, idMap, configBuilder));
+    assertEquals(
+        RocksDbKeyValueStorageEngineFactory.class.getName(),
+        config.get("stores.testState-First_stateful_ParDo.factory"));
+    assertEquals("byteArraySerde", config.get("stores.testState-First_stateful_ParDo.key.serde"));
+    assertEquals("stateValueSerde", config.get("stores.testState-First_stateful_ParDo.msg.serde"));
+    assertNull(config.get("stores.testState-First_stateful_ParDo.changelog"));
+
+    assertEquals(
+        RocksDbKeyValueStorageEngineFactory.class.getName(),
+        config.get("stores.testState-Second_stateful_ParDo.factory"));
+    assertEquals("byteArraySerde", config.get("stores.testState-Second_stateful_ParDo.key.serde"));
+    assertEquals("stateValueSerde", config.get("stores.testState-Second_stateful_ParDo.msg.serde"));
+    assertNull(config.get("stores.testState-Second_stateful_ParDo.changelog"));
+
+    options.setStateDurable(true);
+    SamzaPipelineTranslator.createConfig(
+        pipeline, options, idMap, nonUniqueStateIds, configBuilder);
+    final Config config2 = configBuilder.build();
+    assertEquals(
+        "TestStoreConfig-1-testState-First_stateful_ParDo-changelog",
+        config2.get("stores.testState-First_stateful_ParDo.changelog"));
+    assertEquals(
+        "TestStoreConfig-1-testState-Second_stateful_ParDo-changelog",
+        config2.get("stores.testState-Second_stateful_ParDo.changelog"));
+  }
+
+  @Test
+  public void testUserStoreConfigSameStateIdAndPTransformName() {
+    SamzaPipelineOptions options = PipelineOptionsFactory.create().as(SamzaPipelineOptions.class);
+    options.setJobName("TestStoreConfig");
+    options.setRunner(SamzaRunner.class);
+
+    Pipeline pipeline = Pipeline.create(options);
+    pipeline
+        .apply(
+            Create.empty(TypeDescriptors.kvs(TypeDescriptors.strings(), TypeDescriptors.strings())))
+        .apply(
+            "Same stateful ParDo Name",
+            ParDo.of(
+                new DoFn<KV<String, String>, KV<String, String>>() {
+                  private static final String testState = "testState";
+
+                  @StateId(testState)
+                  private final StateSpec<ValueState<Integer>> state = StateSpecs.value();
+
+                  @ProcessElement
+                  public void processElement(
+                      ProcessContext context, @StateId(testState) ValueState<Integer> state) {
+                    context.output(context.element());
+                  }
+                }))
+        .apply(
+            "Same stateful ParDo Name",
+            ParDo.of(
+                new DoFn<KV<String, String>, Void>() {
+                  private static final String testState = "testState";
+
+                  @StateId(testState)
+                  private final StateSpec<ValueState<Integer>> state = StateSpecs.value();
+
+                  @ProcessElement
+                  public void processElement(
+                      ProcessContext context, @StateId(testState) ValueState<Integer> state) {}
+                }));
+
+    final Map<PValue, String> idMap = PViewToIdMapper.buildIdMap(pipeline);
+    final Set<String> nonUniqueStateIds = StateIdParser.scan(pipeline);
+    final ConfigBuilder configBuilder = new ConfigBuilder(options);
+    SamzaPipelineTranslator.createConfig(
+        pipeline, options, idMap, nonUniqueStateIds, configBuilder);
+    final Config config = configBuilder.build();
+
+    assertEquals(
+        RocksDbKeyValueStorageEngineFactory.class.getName(),
+        config.get("stores.testState-Same_stateful_ParDo_Name.factory"));
+    assertEquals(
+        "byteArraySerde", config.get("stores.testState-Same_stateful_ParDo_Name.key.serde"));
+    assertEquals(
+        "stateValueSerde", config.get("stores.testState-Same_stateful_ParDo_Name.msg.serde"));
+    assertNull(config.get("stores.testState-Same_stateful_ParDo_Name.changelog"));
+
+    assertEquals(
+        RocksDbKeyValueStorageEngineFactory.class.getName(),
+        config.get("stores.testState-Same_stateful_ParDo_Name2.factory"));
+    assertEquals(
+        "byteArraySerde", config.get("stores.testState-Same_stateful_ParDo_Name2.key.serde"));
+    assertEquals(
+        "stateValueSerde", config.get("stores.testState-Same_stateful_ParDo_Name2.msg.serde"));
+    assertNull(config.get("stores.testState-Same_stateful_ParDo_Name2.changelog"));
+
+    options.setStateDurable(true);
+    SamzaPipelineTranslator.createConfig(
+        pipeline, options, idMap, nonUniqueStateIds, configBuilder);
+    final Config config2 = configBuilder.build();
+    assertEquals(
+        "TestStoreConfig-1-testState-Same_stateful_ParDo_Name-changelog",
+        config2.get("stores.testState-Same_stateful_ParDo_Name.changelog"));
+    assertEquals(
+        "TestStoreConfig-1-testState-Same_stateful_ParDo_Name2-changelog",
+        config2.get("stores.testState-Same_stateful_ParDo_Name2.changelog"));
   }
 }

--- a/runners/samza/src/test/java/org/apache/beam/runners/samza/translation/TranslationContextTest.java
+++ b/runners/samza/src/test/java/org/apache/beam/runners/samza/translation/TranslationContextTest.java
@@ -22,8 +22,10 @@ import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.beam.runners.samza.SamzaPipelineOptions;
 import org.apache.beam.runners.samza.runtime.OpMessage;
@@ -60,8 +62,10 @@ public class TranslationContextTest {
           },
           getConfig());
   Map<PValue, String> idMap = new HashMap<>();
+  Set<String> nonUniqueStateIds = new HashSet<>();
   TranslationContext translationContext =
-      new TranslationContext(streamApplicationDescriptor, idMap, mock(SamzaPipelineOptions.class));
+      new TranslationContext(
+          streamApplicationDescriptor, idMap, nonUniqueStateIds, mock(SamzaPipelineOptions.class));
 
   @Test
   public void testRegisterInputMessageStreams() {


### PR DESCRIPTION
This is a cherry pick from OSS
- Original PR: https://github.com/apache/beam/pull/24276

Samza runner support for non-unique stateIds across multiple ParDos
(1) Do not touch existing RocksDB Store Id with stateId used only by one ParDo
(2) Add a prescan logic in SamzaRunner to traverse Beam pipeline topologically and identify non-unique stateIds.
(3) Using the set of non-unique stateIds, introduce a new mapping of user-provided stateIds to store ID 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
