### PR TITLE
Support DoFn metrics in portable Samza Runner  (#25068)

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -391,7 +391,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.38.7.0'
+    project.version = '2.38.8'
 
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -391,7 +391,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.38.8'
+    project.version = '2.38.7.1'
 
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,8 +24,8 @@ offlineRepositoryRoot=offline-repository
 signing.gnupg.executable=gpg
 signing.gnupg.useLegacyGpg=true
 
-version=2.38.7.0
-sdk_version=2.38.7.0
+version=2.38.8
+sdk_version=2.38.8
 # WARNING! Many Beam modules use a custom Gradle plugin that overrides the
 # project version defined here in the `apply` function in
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,8 +24,8 @@ offlineRepositoryRoot=offline-repository
 signing.gnupg.executable=gpg
 signing.gnupg.useLegacyGpg=true
 
-version=2.38.8
-sdk_version=2.38.8
+version=2.38.7.1
+sdk_version=2.38.7.1
 # WARNING! Many Beam modules use a custom Gradle plugin that overrides the
 # project version defined here in the `apply` function in
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaMetricsBundleProgressHandler.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaMetricsBundleProgressHandler.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.samza.runtime;
+
+import static org.apache.beam.runners.core.metrics.MonitoringInfoConstants.TypeUrns.DISTRIBUTION_INT64_TYPE;
+import static org.apache.beam.runners.core.metrics.MonitoringInfoConstants.TypeUrns.LATEST_INT64_TYPE;
+import static org.apache.beam.runners.core.metrics.MonitoringInfoConstants.TypeUrns.SUM_INT64_TYPE;
+import static org.apache.beam.runners.core.metrics.MonitoringInfoEncodings.decodeInt64Counter;
+import static org.apache.beam.runners.core.metrics.MonitoringInfoEncodings.decodeInt64Distribution;
+import static org.apache.beam.runners.core.metrics.MonitoringInfoEncodings.decodeInt64Gauge;
+
+import java.util.Map;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi;
+import org.apache.beam.model.pipeline.v1.MetricsApi;
+import org.apache.beam.runners.core.metrics.DistributionData;
+import org.apache.beam.runners.core.metrics.MonitoringInfoConstants;
+import org.apache.beam.runners.fnexecution.control.BundleProgressHandler;
+import org.apache.beam.runners.samza.metrics.SamzaMetricsContainer;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Distribution;
+import org.apache.beam.sdk.metrics.Gauge;
+import org.apache.beam.sdk.metrics.MetricName;
+import org.apache.beam.sdk.metrics.MetricsContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@inheritDoc} Parses metrics information contained in the bundle progress messages. Passed the
+ * updated metrics to the provided SamzaMetricsContainer.
+ */
+class SamzaMetricsBundleProgressHandler implements BundleProgressHandler {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SamzaMetricsBundleProgressHandler.class);
+  private final String stepName;
+
+  private final SamzaMetricsContainer samzaMetricsContainer;
+  private final Map<String, String> transformIdToUniqueName;
+
+  /**
+   * Constructor of a SamzaMetricsBundleProgressHandler.
+   *
+   * <p>The full metric names in classic mode is {transformUniqueName}:{className}:{metricName}. We
+   * attempt to follow the same format in portable mode, but the monitoringInfos returned by the
+   * worker only contains the transformId. The current solution is to provide a mapping from
+   * transformId back to uniqueName. A future improvement would be making the monitoring infos
+   * contain the uniqueName.
+   *
+   * @param stepName Default stepName provided by the runner.
+   * @param samzaMetricsContainer The destination for publishing the metrics.
+   * @param transformIdToUniqueName A mapping from transformId to uniqueName for pTransforms.
+   */
+  public SamzaMetricsBundleProgressHandler(
+      String stepName,
+      SamzaMetricsContainer samzaMetricsContainer,
+      Map<String, String> transformIdToUniqueName) {
+    this.stepName = stepName;
+    this.samzaMetricsContainer = samzaMetricsContainer;
+    this.transformIdToUniqueName = transformIdToUniqueName;
+  }
+
+  @Override
+  /**
+   * {@inheritDoc} Handles a progress report from the bundle while it is executing. We choose to
+   * ignore the progress report. The metrics do not have to be updated on every progress report, so
+   * we save computation resources by ignoring it.
+   */
+  public void onProgress(BeamFnApi.ProcessBundleProgressResponse progress) {}
+
+  @Override
+  /**
+   * {@inheritDoc} Handles the bundle's completion report. Parses the monitoringInfos in the
+   * response, then updates the MetricsRegistry.
+   */
+  public void onCompleted(BeamFnApi.ProcessBundleResponse response) {
+    response.getMonitoringInfosList().stream()
+        .filter(monitoringInfo -> !monitoringInfo.getPayload().isEmpty())
+        .forEach(this::parseAndUpdateMetric);
+  }
+
+  /**
+   * Parses the metric contained in monitoringInfo, then publishes the metric to the
+   * metricContainer.
+   *
+   * <p>We attempt to construct a classic mode metricName
+   * ({transformUniqueName}:{className}:{metricName}). All the info should be in the labels, but we
+   * have fallbacks in case the labels don't exist.
+   *
+   * <p>Priorities for the transformUniqueName 1. Obtained transformUniqueName using the
+   * transformIdToUniqueName 2. The transformId provided by the monitoringInfo 3. The stepName
+   * provided by the runner, which maybe a result of fusing.
+   *
+   * <p>Priorities for the className 1. The namespace label 2. The monitoringInfo urn. Copying the
+   * implementation in MonitoringInfoMetricName.
+   *
+   * <p>Priorities for the metricName 1. The name label 2. The monitoringInfo urn. Copying the
+   * implementation in MonitoringInfoMetricName.
+   *
+   * @see
+   *     org.apache.beam.runners.core.metrics.MonitoringInfoMetricName#of(MetricsApi.MonitoringInfo)
+   */
+  private void parseAndUpdateMetric(MetricsApi.MonitoringInfo monitoringInfo) {
+    String pTransformId =
+        monitoringInfo.getLabelsOrDefault(MonitoringInfoConstants.Labels.PTRANSFORM, stepName);
+    String transformUniqueName = transformIdToUniqueName.getOrDefault(pTransformId, pTransformId);
+    String className =
+        monitoringInfo.getLabelsOrDefault(
+            MonitoringInfoConstants.Labels.NAMESPACE, monitoringInfo.getUrn());
+    String userMetricName =
+        monitoringInfo.getLabelsOrDefault(
+            MonitoringInfoConstants.Labels.NAME, monitoringInfo.getLabelsMap().toString());
+
+    MetricsContainer metricsContainer = samzaMetricsContainer.getContainer(transformUniqueName);
+    MetricName metricName = MetricName.named(className, userMetricName);
+
+    switch (monitoringInfo.getType()) {
+      case SUM_INT64_TYPE:
+        Counter counter = metricsContainer.getCounter(metricName);
+        counter.inc(decodeInt64Counter(monitoringInfo.getPayload()));
+        break;
+
+      case DISTRIBUTION_INT64_TYPE:
+        Distribution distribution = metricsContainer.getDistribution(metricName);
+        DistributionData data = decodeInt64Distribution(monitoringInfo.getPayload());
+        distribution.update(data.sum(), data.count(), data.min(), data.max());
+        break;
+
+      case LATEST_INT64_TYPE:
+        Gauge gauge = metricsContainer.getGauge(metricName);
+        // Gauge doesn't expose update as public. This will reset the timestamp.
+
+        gauge.set(decodeInt64Gauge(monitoringInfo.getPayload()).value());
+        break;
+
+      default:
+        LOG.warn("Unsupported metric type {}", monitoringInfo.getType());
+    }
+  }
+}

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaMetricsBundleProgressHandler.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaMetricsBundleProgressHandler.java
@@ -17,22 +17,18 @@
  */
 package org.apache.beam.runners.samza.runtime;
 
-import static org.apache.beam.runners.core.metrics.MonitoringInfoConstants.TypeUrns.DISTRIBUTION_INT64_TYPE;
 import static org.apache.beam.runners.core.metrics.MonitoringInfoConstants.TypeUrns.LATEST_INT64_TYPE;
 import static org.apache.beam.runners.core.metrics.MonitoringInfoConstants.TypeUrns.SUM_INT64_TYPE;
 import static org.apache.beam.runners.core.metrics.MonitoringInfoEncodings.decodeInt64Counter;
-import static org.apache.beam.runners.core.metrics.MonitoringInfoEncodings.decodeInt64Distribution;
 import static org.apache.beam.runners.core.metrics.MonitoringInfoEncodings.decodeInt64Gauge;
 
 import java.util.Map;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.model.pipeline.v1.MetricsApi;
-import org.apache.beam.runners.core.metrics.DistributionData;
 import org.apache.beam.runners.core.metrics.MonitoringInfoConstants;
 import org.apache.beam.runners.fnexecution.control.BundleProgressHandler;
 import org.apache.beam.runners.samza.metrics.SamzaMetricsContainer;
 import org.apache.beam.sdk.metrics.Counter;
-import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.Gauge;
 import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricsContainer;
@@ -132,12 +128,6 @@ class SamzaMetricsBundleProgressHandler implements BundleProgressHandler {
       case SUM_INT64_TYPE:
         Counter counter = metricsContainer.getCounter(metricName);
         counter.inc(decodeInt64Counter(monitoringInfo.getPayload()));
-        break;
-
-      case DISTRIBUTION_INT64_TYPE:
-        Distribution distribution = metricsContainer.getDistribution(metricName);
-        DistributionData data = decodeInt64Distribution(monitoringInfo.getPayload());
-        distribution.update(data.sum(), data.count(), data.min(), data.max());
         break;
 
       case LATEST_INT64_TYPE:

--- a/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/SamzaMetricsBundleProgressHandlerTest.java
+++ b/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/SamzaMetricsBundleProgressHandlerTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.samza.runtime;
+
+import static org.apache.beam.runners.core.metrics.MonitoringInfoConstants.TypeUrns.DISTRIBUTION_INT64_TYPE;
+import static org.apache.beam.runners.core.metrics.MonitoringInfoConstants.TypeUrns.LATEST_INT64_TYPE;
+import static org.apache.beam.runners.core.metrics.MonitoringInfoConstants.TypeUrns.SUM_INT64_TYPE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi;
+import org.apache.beam.model.pipeline.v1.MetricsApi;
+import org.apache.beam.runners.core.metrics.CounterCell;
+import org.apache.beam.runners.core.metrics.DistributionCell;
+import org.apache.beam.runners.core.metrics.GaugeCell;
+import org.apache.beam.runners.core.metrics.MonitoringInfoConstants;
+import org.apache.beam.runners.samza.metrics.SamzaMetricsContainer;
+import org.apache.beam.sdk.metrics.MetricName;
+import org.apache.beam.vendor.grpc.v1p48p1.com.google.protobuf.ByteString;
+import org.apache.samza.metrics.MetricsRegistryMap;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SamzaMetricsBundleProgressHandlerTest {
+
+  public static final String EXPECTED_NAMESPACE = "namespace";
+  public static final String EXPECTED_COUNTER_NAME = "counterName";
+  private MetricsRegistryMap metricsRegistryMap;
+  private SamzaMetricsContainer samzaMetricsContainer;
+
+  private SamzaMetricsBundleProgressHandler samzaMetricsBundleProgressHandler;
+  private String stepName = "stepName";
+  Map<String, String> transformIdToUniqueName = new HashMap<>();
+
+  @Before
+  public void setup() {
+    metricsRegistryMap = new MetricsRegistryMap();
+    samzaMetricsContainer = new SamzaMetricsContainer(metricsRegistryMap);
+    samzaMetricsBundleProgressHandler =
+        new SamzaMetricsBundleProgressHandler(
+            stepName, samzaMetricsContainer, transformIdToUniqueName);
+  }
+
+  @Test
+  public void testCounter() {
+    // Hex for 123
+    byte[] payload = "\173".getBytes(Charset.defaultCharset());
+
+    MetricsApi.MonitoringInfo monitoringInfo =
+        MetricsApi.MonitoringInfo.newBuilder()
+            .setType(SUM_INT64_TYPE)
+            .setPayload(ByteString.copyFrom(payload))
+            .putLabels(MonitoringInfoConstants.Labels.NAMESPACE, EXPECTED_NAMESPACE)
+            .putLabels(MonitoringInfoConstants.Labels.NAME, EXPECTED_COUNTER_NAME)
+            .build();
+    BeamFnApi.ProcessBundleResponse response =
+        BeamFnApi.ProcessBundleResponse.newBuilder().addMonitoringInfos(monitoringInfo).build();
+
+    // Execute
+    samzaMetricsBundleProgressHandler.onCompleted(response);
+
+    // Verify
+    MetricName metricName = MetricName.named(EXPECTED_NAMESPACE, EXPECTED_COUNTER_NAME);
+    CounterCell counter =
+        (CounterCell) samzaMetricsContainer.getContainer(stepName).getCounter(metricName);
+
+    assertEquals(counter.getCumulative(), (Long) 123L);
+  }
+
+  @Test
+  public void testGauge() {
+    // TimeStamp = 0, Value = 123
+    byte[] payload = "\000\173".getBytes(Charset.defaultCharset());
+
+    MetricsApi.MonitoringInfo monitoringInfo =
+        MetricsApi.MonitoringInfo.newBuilder()
+            .setType(LATEST_INT64_TYPE)
+            .setPayload(ByteString.copyFrom(payload))
+            .putLabels(MonitoringInfoConstants.Labels.NAMESPACE, EXPECTED_NAMESPACE)
+            .putLabels(MonitoringInfoConstants.Labels.NAME, EXPECTED_COUNTER_NAME)
+            .build();
+    BeamFnApi.ProcessBundleResponse response =
+        BeamFnApi.ProcessBundleResponse.newBuilder().addMonitoringInfos(monitoringInfo).build();
+
+    // Execute
+    samzaMetricsBundleProgressHandler.onCompleted(response);
+
+    // Verify
+    MetricName metricName = MetricName.named(EXPECTED_NAMESPACE, EXPECTED_COUNTER_NAME);
+    GaugeCell gauge = (GaugeCell) samzaMetricsContainer.getContainer(stepName).getGauge(metricName);
+
+    assertEquals(123L, gauge.getCumulative().value());
+    assertTrue(
+        gauge.getCumulative().timestamp().isBefore(Instant.now().plus(Duration.millis(500))));
+    assertTrue(
+        gauge.getCumulative().timestamp().isAfter(Instant.now().minus(Duration.millis(500))));
+  }
+
+  @Test
+  public void testDistribution() {
+    // Count = 123, sum = 124, min = 125, max = 126
+    byte[] payload = "\173\174\175\176".getBytes(Charset.defaultCharset());
+
+    MetricsApi.MonitoringInfo monitoringInfo =
+        MetricsApi.MonitoringInfo.newBuilder()
+            .setType(DISTRIBUTION_INT64_TYPE)
+            .setPayload(ByteString.copyFrom(payload))
+            .putLabels(MonitoringInfoConstants.Labels.NAMESPACE, EXPECTED_NAMESPACE)
+            .putLabels(MonitoringInfoConstants.Labels.NAME, EXPECTED_COUNTER_NAME)
+            .build();
+    BeamFnApi.ProcessBundleResponse response =
+        BeamFnApi.ProcessBundleResponse.newBuilder().addMonitoringInfos(monitoringInfo).build();
+
+    // Execute
+    samzaMetricsBundleProgressHandler.onCompleted(response);
+
+    // Verify
+    MetricName metricName = MetricName.named(EXPECTED_NAMESPACE, EXPECTED_COUNTER_NAME);
+    DistributionCell gauge =
+        (DistributionCell) samzaMetricsContainer.getContainer(stepName).getDistribution(metricName);
+
+    assertEquals(123L, gauge.getCumulative().count());
+    assertEquals(124L, gauge.getCumulative().sum());
+    assertEquals(125L, gauge.getCumulative().min());
+    assertEquals(126L, gauge.getCumulative().max());
+  }
+
+  @Test
+  public void testEmptyPayload() {
+
+    byte[] emptyPayload = "".getBytes(Charset.defaultCharset());
+
+    MetricsApi.MonitoringInfo emptyMonitoringInfo =
+        MetricsApi.MonitoringInfo.newBuilder()
+            .setType(SUM_INT64_TYPE)
+            .setPayload(ByteString.copyFrom(emptyPayload))
+            .putLabels(MonitoringInfoConstants.Labels.NAMESPACE, EXPECTED_NAMESPACE)
+            .putLabels(MonitoringInfoConstants.Labels.NAME, EXPECTED_COUNTER_NAME)
+            .build();
+    // Hex for 123
+    byte[] payload = "\173".getBytes(Charset.defaultCharset());
+
+    MetricsApi.MonitoringInfo monitoringInfo =
+        MetricsApi.MonitoringInfo.newBuilder()
+            .setType(SUM_INT64_TYPE)
+            .setPayload(ByteString.copyFrom(payload))
+            .putLabels(MonitoringInfoConstants.Labels.NAMESPACE, EXPECTED_NAMESPACE)
+            .putLabels(MonitoringInfoConstants.Labels.NAME, EXPECTED_COUNTER_NAME)
+            .build();
+    BeamFnApi.ProcessBundleResponse response =
+        BeamFnApi.ProcessBundleResponse.newBuilder()
+            .addMonitoringInfos(emptyMonitoringInfo)
+            .addMonitoringInfos(monitoringInfo)
+            .addMonitoringInfos(emptyMonitoringInfo)
+            .build();
+
+    // Execute
+    samzaMetricsBundleProgressHandler.onCompleted(response);
+
+    // Verify
+    MetricName metricName = MetricName.named(EXPECTED_NAMESPACE, EXPECTED_COUNTER_NAME);
+    CounterCell counter =
+        (CounterCell) samzaMetricsContainer.getContainer(stepName).getCounter(metricName);
+
+    assertEquals(counter.getCumulative(), (Long) 123L);
+  }
+}

--- a/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/SamzaMetricsBundleProgressHandlerTest.java
+++ b/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/SamzaMetricsBundleProgressHandlerTest.java
@@ -17,11 +17,11 @@
  */
 package org.apache.beam.runners.samza.runtime;
 
-import static org.apache.beam.runners.core.metrics.MonitoringInfoConstants.TypeUrns.DISTRIBUTION_INT64_TYPE;
 import static org.apache.beam.runners.core.metrics.MonitoringInfoConstants.TypeUrns.LATEST_INT64_TYPE;
 import static org.apache.beam.runners.core.metrics.MonitoringInfoConstants.TypeUrns.SUM_INT64_TYPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.nio.charset.Charset;
 import java.util.HashMap;
@@ -29,12 +29,12 @@ import java.util.Map;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.model.pipeline.v1.MetricsApi;
 import org.apache.beam.runners.core.metrics.CounterCell;
-import org.apache.beam.runners.core.metrics.DistributionCell;
 import org.apache.beam.runners.core.metrics.GaugeCell;
 import org.apache.beam.runners.core.metrics.MonitoringInfoConstants;
 import org.apache.beam.runners.samza.metrics.SamzaMetricsContainer;
 import org.apache.beam.sdk.metrics.MetricName;
-import org.apache.beam.vendor.grpc.v1p48p1.com.google.protobuf.ByteString;
+import org.apache.beam.vendor.grpc.v1p43p2.com.google.protobuf.ByteString;
+import org.apache.samza.config.Config;
 import org.apache.samza.metrics.MetricsRegistryMap;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -46,6 +46,7 @@ public class SamzaMetricsBundleProgressHandlerTest {
   public static final String EXPECTED_NAMESPACE = "namespace";
   public static final String EXPECTED_COUNTER_NAME = "counterName";
   private MetricsRegistryMap metricsRegistryMap;
+  private Config config;
   private SamzaMetricsContainer samzaMetricsContainer;
 
   private SamzaMetricsBundleProgressHandler samzaMetricsBundleProgressHandler;
@@ -55,7 +56,8 @@ public class SamzaMetricsBundleProgressHandlerTest {
   @Before
   public void setup() {
     metricsRegistryMap = new MetricsRegistryMap();
-    samzaMetricsContainer = new SamzaMetricsContainer(metricsRegistryMap);
+    config = mock(Config.class);
+    samzaMetricsContainer = new SamzaMetricsContainer(metricsRegistryMap, config);
     samzaMetricsBundleProgressHandler =
         new SamzaMetricsBundleProgressHandler(
             stepName, samzaMetricsContainer, transformIdToUniqueName);
@@ -114,35 +116,6 @@ public class SamzaMetricsBundleProgressHandlerTest {
         gauge.getCumulative().timestamp().isBefore(Instant.now().plus(Duration.millis(500))));
     assertTrue(
         gauge.getCumulative().timestamp().isAfter(Instant.now().minus(Duration.millis(500))));
-  }
-
-  @Test
-  public void testDistribution() {
-    // Count = 123, sum = 124, min = 125, max = 126
-    byte[] payload = "\173\174\175\176".getBytes(Charset.defaultCharset());
-
-    MetricsApi.MonitoringInfo monitoringInfo =
-        MetricsApi.MonitoringInfo.newBuilder()
-            .setType(DISTRIBUTION_INT64_TYPE)
-            .setPayload(ByteString.copyFrom(payload))
-            .putLabels(MonitoringInfoConstants.Labels.NAMESPACE, EXPECTED_NAMESPACE)
-            .putLabels(MonitoringInfoConstants.Labels.NAME, EXPECTED_COUNTER_NAME)
-            .build();
-    BeamFnApi.ProcessBundleResponse response =
-        BeamFnApi.ProcessBundleResponse.newBuilder().addMonitoringInfos(monitoringInfo).build();
-
-    // Execute
-    samzaMetricsBundleProgressHandler.onCompleted(response);
-
-    // Verify
-    MetricName metricName = MetricName.named(EXPECTED_NAMESPACE, EXPECTED_COUNTER_NAME);
-    DistributionCell gauge =
-        (DistributionCell) samzaMetricsContainer.getContainer(stepName).getDistribution(metricName);
-
-    assertEquals(123L, gauge.getCumulative().count());
-    assertEquals(124L, gauge.getCumulative().sum());
-    assertEquals(125L, gauge.getCumulative().min());
-    assertEquals(126L, gauge.getCumulative().max());
   }
 
   @Test


### PR DESCRIPTION
- Implement SamzaMetricsBundleProgressHandler
- Modify SamzaDoFnRunners to use SamzaMetricsBundleProgressHandler, instead of BundleProgressHandler.ignored()
- Add unit tests
- Refactor stepName member field in SamzaDoFnRunners