### PR TITLE
Move Samza portable metric warning logs to debug level

### DIFF
--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaMetricsBundleProgressHandler.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaMetricsBundleProgressHandler.java
@@ -138,7 +138,9 @@ class SamzaMetricsBundleProgressHandler implements BundleProgressHandler {
         break;
 
       default:
-        LOG.debug("Unsupported metric type {}", monitoringInfo.getType());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Unsupported metric type {}", monitoringInfo.getType());
+        }
     }
   }
 }

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaMetricsBundleProgressHandler.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaMetricsBundleProgressHandler.java
@@ -138,7 +138,7 @@ class SamzaMetricsBundleProgressHandler implements BundleProgressHandler {
         break;
 
       default:
-        LOG.warn("Unsupported metric type {}", monitoringInfo.getType());
+        LOG.debug("Unsupported metric type {}", monitoringInfo.getType());
     }
   }
 }


### PR DESCRIPTION
Since we don't support distribution metrics yet, warning level logs are too noisy. Lowering the log level to debug.

This shouldn't be a problem on the master branch, so we keep the changes here.