### PR TITLE
Flink version update

### DIFF
--- a/runners/flink/1.16/build.gradle
+++ b/runners/flink/1.16/build.gradle
@@ -21,7 +21,7 @@ def basePath = '..'
 /* All properties required for loading the Flink build script */
 project.ext {
   // Set the version of all Flink-related dependencies here.
-  flink_version = '1.16.0'
+  flink_version = '11600.3'
   // Version specific code overrides.
   main_source_overrides = ["${basePath}/1.12/src/main/java", "${basePath}/1.13/src/main/java", "${basePath}/1.14/src/main/java", "${basePath}/1.15/src/main/java", './src/main/java']
   test_source_overrides = ["${basePath}/1.12/src/test/java", "${basePath}/1.13/src/test/java", "${basePath}/1.14/src/test/java", "${basePath}/1.15/src/test/java", './src/test/java']

--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -148,10 +148,8 @@ dependencies {
   implementation library.java.joda_time
   implementation library.java.args4j
 
-  /* Flink 1.15 shades all remaining scala dependencies and therefor does not depend on a specific version of Scala anymore.
-   * Flink 1.16 onwards, flink version is 11600.* and does not depend on a specific version of Scala anymore.
-   */
-  if (flink_version.compareTo("1.15") >= 0 || flink_version.compareTo("11600.3") >= 0) {
+  // Flink 1.15 shades all remaining scala dependencies and therefor does not depend on a specific version of Scala anymore
+  if (flink_version.compareTo("1.15") >= 0) {
     implementation "org.apache.flink:flink-clients:$flink_version"
     // Runtime dependencies are not included in Beam's generated pom.xml, so we must declare flink-clients in implementation
     // configuration (https://issues.apache.org/jira/browse/BEAM-11732).
@@ -185,7 +183,7 @@ dependencies {
   implementation "org.apache.flink:flink-metrics-core:$flink_version"
   implementation "org.apache.flink:flink-java:$flink_version"
 
-  if (flink_version.compareTo("1.14") >= 0 || flink_version.compareTo("11600.3") >= 0) {
+  if (flink_version.compareTo("1.14") >= 0) {
     implementation "org.apache.flink:flink-runtime:$flink_version"
     implementation "org.apache.flink:flink-optimizer:$flink_version"
     implementation "org.apache.flink:flink-metrics-core:$flink_version"

--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -406,3 +406,18 @@ createPipelineOptionsTableTask('Python')
 // Update the pipeline options documentation before running the tests
 test.dependsOn(generatePipelineOptionsTableJava)
 test.dependsOn(generatePipelineOptionsTablePython)
+
+repositories {
+  maven {
+    name 'ext-libraries'
+    url 'https://linkedin.jfrog.io/artifactory/flink-li-custom/'
+  }
+}
+
+dependencies {
+  implementation "org.apache.flink:flink-runtime:$flink_version"
+  implementation "org.apache.flink:flink-optimizer:$flink_version"
+  implementation "org.apache.flink:flink-metrics-core:$flink_version"
+  testImplementation "org.apache.flink:flink-runtime:$flink_version:tests"
+  testImplementation "org.apache.flink:flink-rpc-akka:$flink_version"
+}

--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -127,6 +127,13 @@ configurations {
   examplesJavaIntegrationTest
 }
 
+repositories {
+  maven {
+    name 'linkedin-jfrog'
+    url 'https://linkedin.jfrog.io/artifactory/flink-li-custom/'
+  }
+}
+
 dependencies {
   compileOnly project(":sdks:java:build-tools")
   implementation library.java.vendored_guava_26_0_jre
@@ -141,8 +148,10 @@ dependencies {
   implementation library.java.joda_time
   implementation library.java.args4j
 
-  // Flink 1.15 shades all remaining scala dependencies and therefor does not depend on a specific version of Scala anymore
-  if (flink_version.compareTo("1.15") >= 0) {
+  /* Flink 1.15 shades all remaining scala dependencies and therefor does not depend on a specific version of Scala anymore.
+   * Flink 1.16 onwards, flink version is 11600.* and does not depend on a specific version of Scala anymore.
+   */
+  if (flink_version.compareTo("1.15") >= 0 || flink_version.compareTo("11600.3") >= 0) {
     implementation "org.apache.flink:flink-clients:$flink_version"
     // Runtime dependencies are not included in Beam's generated pom.xml, so we must declare flink-clients in implementation
     // configuration (https://issues.apache.org/jira/browse/BEAM-11732).
@@ -176,7 +185,7 @@ dependencies {
   implementation "org.apache.flink:flink-metrics-core:$flink_version"
   implementation "org.apache.flink:flink-java:$flink_version"
 
-  if (flink_version.compareTo("1.14") >= 0) {
+  if (flink_version.compareTo("1.14") >= 0 || flink_version.compareTo("11600.3") >= 0) {
     implementation "org.apache.flink:flink-runtime:$flink_version"
     implementation "org.apache.flink:flink-optimizer:$flink_version"
     implementation "org.apache.flink:flink-metrics-core:$flink_version"
@@ -406,18 +415,3 @@ createPipelineOptionsTableTask('Python')
 // Update the pipeline options documentation before running the tests
 test.dependsOn(generatePipelineOptionsTableJava)
 test.dependsOn(generatePipelineOptionsTablePython)
-
-repositories {
-  maven {
-    name 'ext-libraries'
-    url 'https://linkedin.jfrog.io/artifactory/flink-li-custom/'
-  }
-}
-
-dependencies {
-  implementation "org.apache.flink:flink-runtime:$flink_version"
-  implementation "org.apache.flink:flink-optimizer:$flink_version"
-  implementation "org.apache.flink:flink-metrics-core:$flink_version"
-  testImplementation "org.apache.flink:flink-runtime:$flink_version:tests"
-  testImplementation "org.apache.flink:flink-rpc-akka:$flink_version"
-}


### PR DESCRIPTION
### Summary
Fix the Beam build issue to run against latest Flink version.

### Testing 
Tested for all versions of Flink and now Beam is able to fetch the latest Flink artifacts.
```
./gradlew :runners:flink:1.16:build
./gradlew :runners:flink:1.15:build
./gradlew :runners:flink:1.14:build
./gradlew :runners:flink:1.13:build
./gradlew :runners:flink:1.12:build
```