### PR TITLE
Support fusion on the ParDos with user states 

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.10'
+    project.version = '2.45.11'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.10
-sdk_version=2.45.10
+version=2.45.11
+sdk_version=2.45.11
 
 javaVersion=1.8
 

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/FusedPipeline.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/FusedPipeline.java
@@ -35,7 +35,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
 /** A {@link Pipeline} which has been separated into collections of executable components. */
 @AutoValue
 public abstract class FusedPipeline {
-  static FusedPipeline of(
+  public static FusedPipeline of(
       Components components,
       Set<ExecutableStage> environmentalStages,
       Set<PTransformNode> runnerStages,

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/OutputDeduplicator.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/OutputDeduplicator.java
@@ -49,7 +49,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
-class OutputDeduplicator {
+public class OutputDeduplicator {
 
   /**
    * Ensure that no {@link PCollection} output by any of the {@code stages} or {@code
@@ -59,7 +59,7 @@ class OutputDeduplicator {
    * rewritten to produce a partial {@link PCollection}, which are then flattened together via an
    * introduced Flatten node which produces the original output.
    */
-  static DeduplicationResult ensureSingleProducer(
+  public static DeduplicationResult ensureSingleProducer(
       QueryablePipeline pipeline,
       Collection<ExecutableStage> stages,
       Collection<PTransformNode> unfusedTransforms) {
@@ -145,7 +145,7 @@ class OutputDeduplicator {
   }
 
   @AutoValue
-  abstract static class DeduplicationResult {
+  public abstract static class DeduplicationResult {
     private static DeduplicationResult of(
         RunnerApi.Components components,
         Set<PTransformNode> introducedTransforms,
@@ -155,13 +155,13 @@ class OutputDeduplicator {
           components, introducedTransforms, stages, unfused);
     }
 
-    abstract RunnerApi.Components getDeduplicatedComponents();
+    public abstract RunnerApi.Components getDeduplicatedComponents();
 
-    abstract Set<PTransformNode> getIntroducedTransforms();
+    public abstract Set<PTransformNode> getIntroducedTransforms();
 
-    abstract Map<ExecutableStage, ExecutableStage> getDeduplicatedStages();
+    public abstract Map<ExecutableStage, ExecutableStage> getDeduplicatedStages();
 
-    abstract Map<String, PTransformNode> getDeduplicatedTransforms();
+    public abstract Map<String, PTransformNode> getDeduplicatedTransforms();
   }
 
   private static PTransform createFlattenOfPartials(

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineOptions.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineOptions.java
@@ -158,6 +158,13 @@ public interface SamzaPipelineOptions extends PipelineOptions {
 
   void setExecutorServiceForProcessElement(ExecutorService executorService);
 
+  @Description(
+      "The config for enabling fusion for stateful ParDos. Used only in portable mode for now.")
+  @Default.Boolean(false)
+  Boolean getEnableFusionOnStatefulParDos();
+
+  void setEnableFusionOnStatefulParDos(Boolean enableFusion);
+
   class ProcessElementExecutorServiceFactory implements DefaultValueFactory<ExecutorService> {
 
     @Override

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/fusers/SamzaPCollectionFusers.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/fusers/SamzaPCollectionFusers.java
@@ -1,0 +1,379 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.samza.fusers;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.apache.beam.model.pipeline.v1.RunnerApi.ParDoPayload;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Pipeline;
+import org.apache.beam.runners.core.construction.PTransformTranslation;
+import org.apache.beam.runners.core.construction.graph.ExecutableStage;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
+import org.apache.beam.runners.core.construction.graph.QueryablePipeline;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.vendor.grpc.v1p48p1.com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A Fuser that constructs a fused pipeline by fusing as many PCollections into a stage as possible.
+ */
+@SuppressWarnings({
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
+class SamzaPCollectionFusers {
+  private static final Logger LOG = LoggerFactory.getLogger(SamzaPCollectionFusers.class);
+
+  private static final Map<String, FusibilityChecker> URN_FUSIBILITY_CHECKERS =
+      ImmutableMap.<String, FusibilityChecker>builder()
+          .put(PTransformTranslation.PAR_DO_TRANSFORM_URN, SamzaPCollectionFusers::canFuseParDo)
+          .put(
+              PTransformTranslation.SPLITTABLE_PAIR_WITH_RESTRICTION_URN,
+              SamzaPCollectionFusers::canFuseParDo)
+          .put(
+              PTransformTranslation.SPLITTABLE_PROCESS_KEYED_URN,
+              SamzaPCollectionFusers::cannotFuse)
+          .put(
+              PTransformTranslation.SPLITTABLE_PROCESS_ELEMENTS_URN,
+              SamzaPCollectionFusers::cannotFuse)
+          .put(
+              PTransformTranslation.SPLITTABLE_SPLIT_AND_SIZE_RESTRICTIONS_URN,
+              SamzaPCollectionFusers::canFuseParDo)
+          .put(
+              PTransformTranslation.SPLITTABLE_PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS_URN,
+              SamzaPCollectionFusers::cannotFuse)
+          .put(
+              PTransformTranslation.COMBINE_PER_KEY_PRECOMBINE_TRANSFORM_URN,
+              SamzaPCollectionFusers::canFuseCompatibleEnvironment)
+          .put(
+              PTransformTranslation.COMBINE_PER_KEY_MERGE_ACCUMULATORS_TRANSFORM_URN,
+              SamzaPCollectionFusers::canFuseCompatibleEnvironment)
+          .put(
+              PTransformTranslation.COMBINE_PER_KEY_EXTRACT_OUTPUTS_TRANSFORM_URN,
+              SamzaPCollectionFusers::canFuseCompatibleEnvironment)
+          .put(
+              PTransformTranslation.ASSIGN_WINDOWS_TRANSFORM_URN,
+              SamzaPCollectionFusers::canFuseCompatibleEnvironment)
+          .put(PTransformTranslation.FLATTEN_TRANSFORM_URN, SamzaPCollectionFusers::canAlwaysFuse)
+          .put(
+              // GroupByKeys are runner-implemented only. PCollections consumed by a GroupByKey must
+              // be materialized
+              PTransformTranslation.GROUP_BY_KEY_TRANSFORM_URN, SamzaPCollectionFusers::cannotFuse)
+          .put(PTransformTranslation.CREATE_VIEW_TRANSFORM_URN, SamzaPCollectionFusers::cannotFuse)
+          .build();
+  private static final FusibilityChecker DEFAULT_FUSIBILITY_CHECKER =
+      SamzaPCollectionFusers::unknownTransformFusion;
+
+  // TODO: Migrate
+  private static final Map<String, CompatibilityChecker> URN_COMPATIBILITY_CHECKERS =
+      ImmutableMap.<String, CompatibilityChecker>builder()
+          .put(
+              PTransformTranslation.PAR_DO_TRANSFORM_URN,
+              SamzaPCollectionFusers::parDoCompatibility)
+          .put(
+              PTransformTranslation.SPLITTABLE_PAIR_WITH_RESTRICTION_URN,
+              SamzaPCollectionFusers::parDoCompatibility)
+          .put(
+              PTransformTranslation.SPLITTABLE_SPLIT_AND_SIZE_RESTRICTIONS_URN,
+              SamzaPCollectionFusers::parDoCompatibility)
+          .put(
+              PTransformTranslation.SPLITTABLE_PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS_URN,
+              SamzaPCollectionFusers::parDoCompatibility)
+          .put(
+              PTransformTranslation.COMBINE_PER_KEY_PRECOMBINE_TRANSFORM_URN,
+              SamzaPCollectionFusers::compatibleEnvironments)
+          .put(
+              PTransformTranslation.COMBINE_PER_KEY_MERGE_ACCUMULATORS_TRANSFORM_URN,
+              SamzaPCollectionFusers::compatibleEnvironments)
+          .put(
+              PTransformTranslation.COMBINE_PER_KEY_EXTRACT_OUTPUTS_TRANSFORM_URN,
+              SamzaPCollectionFusers::compatibleEnvironments)
+          .put(
+              PTransformTranslation.ASSIGN_WINDOWS_TRANSFORM_URN,
+              SamzaPCollectionFusers::compatibleEnvironments)
+          .put(PTransformTranslation.FLATTEN_TRANSFORM_URN, SamzaPCollectionFusers::noCompatibility)
+          .put(
+              PTransformTranslation.GROUP_BY_KEY_TRANSFORM_URN,
+              SamzaPCollectionFusers::noCompatibility)
+          .put(
+              PTransformTranslation.CREATE_VIEW_TRANSFORM_URN,
+              SamzaPCollectionFusers::noCompatibility)
+          .build();
+  private static final CompatibilityChecker DEFAULT_COMPATIBILITY_CHECKER =
+      SamzaPCollectionFusers::unknownTransformCompatibility;
+
+  /** Returns true if the PTransform node for the given input PCollection can be fused across. */
+  public static boolean canFuse(
+      PTransformNode transformNode,
+      Environment environment,
+      PCollectionNode candidate,
+      Collection<PCollectionNode> stagePCollections,
+      QueryablePipeline pipeline) {
+    return URN_FUSIBILITY_CHECKERS
+        .getOrDefault(transformNode.getTransform().getSpec().getUrn(), DEFAULT_FUSIBILITY_CHECKER)
+        .canFuse(transformNode, environment, candidate, stagePCollections, pipeline);
+  }
+
+  /**
+   * Returns true if the two PTransforms are compatible such that they can be executed in the same
+   * environment.
+   */
+  public static boolean isCompatible(
+      PTransformNode left, PTransformNode right, QueryablePipeline pipeline) {
+    CompatibilityChecker leftChecker =
+        URN_COMPATIBILITY_CHECKERS.getOrDefault(
+            left.getTransform().getSpec().getUrn(), DEFAULT_COMPATIBILITY_CHECKER);
+    CompatibilityChecker rightChecker =
+        URN_COMPATIBILITY_CHECKERS.getOrDefault(
+            right.getTransform().getSpec().getUrn(), DEFAULT_COMPATIBILITY_CHECKER);
+    // The nodes are mutually compatible
+    return leftChecker.isCompatible(left, right, pipeline)
+        && rightChecker.isCompatible(right, left, pipeline);
+  }
+
+  // For the following methods, these should be called if the ptransform is consumed by a
+  // PCollection output by the ExecutableStage, to determine if it can be fused into that
+  // Subgraph
+
+  private interface FusibilityChecker {
+    /**
+     * Determine if a {@link PTransformNode} can be fused into an existing {@link ExecutableStage}.
+     */
+    boolean canFuse(
+        PTransformNode transformNode,
+        Environment environment,
+        @SuppressWarnings("unused") PCollectionNode candidate,
+        Collection<PCollectionNode> stagePCollections,
+        QueryablePipeline pipeline);
+  }
+
+  private interface CompatibilityChecker {
+    /**
+     * Determine if two {@link PTransformNode PTransforms} can be fused into a new stage. This
+     * determines sibling fusion for new {@link ExecutableStage stages}.
+     */
+    boolean isCompatible(
+        PTransformNode newNode, PTransformNode otherNode, QueryablePipeline pipeline);
+  }
+
+  /**
+   * A ParDo can be fused into a stage if it executes in the same Environment as that stage, and no
+   * transform that are upstream of any of its side input are present in that stage.
+   *
+   * <p>A ParDo that consumes a side input cannot process an element until all of the side inputs
+   * contain data for the side input window that contains the element.
+   */
+  private static boolean canFuseParDo(
+      PTransformNode parDo,
+      Environment environment,
+      PCollectionNode candidate,
+      Collection<PCollectionNode> stagePCollections,
+      QueryablePipeline pipeline) {
+    Optional<Environment> env = pipeline.getEnvironment(parDo);
+    checkArgument(
+        env.isPresent(),
+        "A %s must have an %s associated with it",
+        ParDoPayload.class.getSimpleName(),
+        Environment.class.getSimpleName());
+    if (!env.get().equals(environment)) {
+      // The PCollection's producer and this ParDo execute in different environments, so fusion
+      // is never possible.
+      return false;
+    }
+    try {
+      ParDoPayload payload = ParDoPayload.parseFrom(parDo.getTransform().getSpec().getPayload());
+      if (Maps.filterKeys(
+              parDo.getTransform().getInputsMap(),
+              s -> payload.getTimerFamilySpecsMap().containsKey(s))
+          .values()
+          .contains(candidate.getId())) {
+        // Allow fusion across timer PCollections because they are a self loop.
+        return true;
+      } else if (payload.getTimerFamilySpecsCount() > 0) {
+        // Inputs to a ParDo that uses Timers must be key-partitioned, and elements for
+        // a key must execute serially. To avoid checking if the rest of the stage is
+        // key-partitioned and preserves keys, these ParDos do not fuse into an existing stage.
+        return false;
+      } else if (!pipeline.getSideInputs(parDo).isEmpty()) {
+        // At execution time, a Runner is required to only provide inputs to a PTransform that, at
+        // the time the PTransform processes them, the associated window is ready in all side inputs
+        // that the PTransform consumes. For an arbitrary stage, it is significantly complex for the
+        // runner to determine this for each input. As a result, we break fusion to simplify this
+        // inspection. In general, a ParDo which consumes side inputs cannot be fused into an
+        // executable stage alongside any transforms which are upstream of any of its side inputs.
+        return false;
+      }
+    } catch (InvalidProtocolBufferException e) {
+      throw new IllegalArgumentException(e);
+    }
+    return true;
+  }
+
+  private static boolean parDoCompatibility(
+      PTransformNode parDo, PTransformNode other, QueryablePipeline pipeline) {
+    // Implicitly true if we are attempting to fuse against oneself. This case comes up for
+    // PCollections representing timers since they create a self-loop in the graph.
+    return parDo.equals(other)
+        // This is a convenience rather than a strict requirement. In general, a ParDo that consumes
+        // side inputs can be fused with other transforms in the same environment which are not
+        // upstream of any of the side inputs.
+        || (pipeline.getSideInputs(parDo).isEmpty()
+            // We purposefully break fusion here to provide runners the opportunity to insert a
+            // grouping operation to simplify implementing support for ParDo's that contain timers.
+            // We would not need to do this if we had the ability to mark upstream transforms as
+            // key preserving or if runners could execute ParDos containing timers in a distributed
+            // fashion for a single key.
+            && pipeline.getTimers(parDo).isEmpty()
+            && compatibleEnvironments(parDo, other, pipeline));
+  }
+
+  /**
+   * A WindowInto can be fused into a stage if it executes in the same Environment as that stage.
+   */
+  private static boolean canFuseCompatibleEnvironment(
+      PTransformNode operation,
+      Environment environment,
+      @SuppressWarnings("unused") PCollectionNode candidate,
+      @SuppressWarnings("unused") Collection<PCollectionNode> stagePCollections,
+      QueryablePipeline pipeline) {
+    // WindowInto transforms may not have an environment
+    Optional<Environment> operationEnvironment = pipeline.getEnvironment(operation);
+    return environment.equals(operationEnvironment.orElse(null));
+  }
+
+  private static boolean compatibleEnvironments(
+      PTransformNode left, PTransformNode right, QueryablePipeline pipeline) {
+    return pipeline.getEnvironment(left).equals(pipeline.getEnvironment(right));
+  }
+
+  /**
+   * Flatten can be fused into any stage.
+   *
+   * <p>If the assumption that for each {@link PCollection}, an element is produced in that {@link
+   * PCollection} via a single path through the {@link Pipeline} DAG, a Flatten can appear in each
+   * stage that produces any of its input {@link PCollection PCollections}, as all of its inputs
+   * will reach it via only one of those paths.
+   *
+   * <p>As flatten consumes multiple inputs and produces a single output, there are two cases that
+   * must be considered for the inputs.
+   *
+   * <ul>
+   *   <li>All of the producers of all inputs are within a single stage
+   *   <li>The producers of the inputs are in two or more stages
+   * </ul>
+   *
+   * <p>If all of the producers exist within a single stage, this is identical to any other
+   * transform that consumes a single input - the output PCollection is materialized based only on
+   * its consumers.
+   *
+   * <p>If the producers exist within separate stages, there are two other considerations:
+   *
+   * <ul>
+   *   <li>The output PCollection must be materialized in all cases (has consumers which cannot be
+   *       fused into at least one of the upstream stages).
+   *   <li>All of the consumers of the output PCollection can be fused into at least one of the
+   *       producing stages.
+   * </ul>
+   *
+   * <p>For the former case, this again is identical to a transform that produces a materialized
+   * {@link PCollection}; each path to the {@link Flatten} produces elements for the input {@link
+   * PCollection}, and the output is materialized and consumed by downstream transforms identically
+   * to any other materialized {@link PCollection}.
+   *
+   * <p>For the latter, where fusion is possible into at least one of the producer stages, Flatten
+   * unzipping is performed. This consists of the following steps:
+   *
+   * <ol>
+   *   <li>The flatten is fused into each upstream stage
+   *   <li>Each stage which contains a producer that can be fused with the output {@link
+   *       PCollection} fuses that {@link PCollection}. Elements produced by that stage for the
+   *       output of the flatten are never materialized.
+   *   <li>Each stage which cannot be fused with the output {@link PCollection} materializes the
+   *       output of the {@link Flatten}. All of the downstream consumers exist in a stage which
+   *       reads from the output of that {@link Flatten}, which contains all of the elements from
+   *       the stages that could not fuse with those consumers.
+   * </ol>
+   */
+  private static boolean canAlwaysFuse(
+      @SuppressWarnings("unused") PTransformNode flatten,
+      @SuppressWarnings("unused") Environment environment,
+      @SuppressWarnings("unused") PCollectionNode candidate,
+      @SuppressWarnings("unused") Collection<PCollectionNode> stagePCollections,
+      @SuppressWarnings("unused") QueryablePipeline pipeline) {
+    return true;
+  }
+
+  private static boolean cannotFuse(
+      @SuppressWarnings("unused") PTransformNode cannotFuse,
+      @SuppressWarnings("unused") Environment environment,
+      @SuppressWarnings("unused") PCollectionNode candidate,
+      @SuppressWarnings("unused") Collection<PCollectionNode> stagePCollections,
+      @SuppressWarnings("unused") QueryablePipeline pipeline) {
+    return false;
+  }
+
+  private static boolean noCompatibility(
+      @SuppressWarnings("unused") PTransformNode self,
+      @SuppressWarnings("unused") PTransformNode other,
+      @SuppressWarnings("unused") QueryablePipeline pipeline) {
+    // TODO: There is performance to be gained if the output of a flatten is fused into a stage
+    // where its output is wholly consumed after a fusion break. This requires slightly more
+    // lookahead.
+    return false;
+  }
+
+  // Things with unknown URNs either execute within their own stage or are executed by the runner.
+  // In either case, assume the system is capable of executing the expressed transform
+  private static boolean unknownTransformFusion(
+      PTransformNode transform,
+      @SuppressWarnings("unused") Environment environment,
+      @SuppressWarnings("unused") PCollectionNode candidate,
+      @SuppressWarnings("unused") Collection<PCollectionNode> stagePCollections,
+      @SuppressWarnings("unused") QueryablePipeline pipeline) {
+    LOG.debug(
+        "Unknown {} {} will not fuse into an existing {}",
+        PTransform.class.getSimpleName(),
+        transform.getTransform(),
+        ExecutableStage.class.getSimpleName());
+    return false;
+  }
+
+  // Things with unknown URNs either execute within their own stage or are executed by the runner.
+  // In either case, assume the system is capable of executing the expressed transform
+  private static boolean unknownTransformCompatibility(
+      PTransformNode transform,
+      @SuppressWarnings("unused") PTransformNode other,
+      @SuppressWarnings("unused") QueryablePipeline pipeline) {
+    LOG.debug(
+        "Unknown {} {} will not root a {} with other {}",
+        PTransform.class.getSimpleName(),
+        transform.getTransform(),
+        ExecutableStage.class.getSimpleName(),
+        PTransform.class.getSimpleName());
+    return false;
+  }
+}

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/fusers/SamzaPipelineFuser.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/fusers/SamzaPipelineFuser.java
@@ -1,0 +1,472 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.samza.fusers;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
+
+import com.google.auto.value.AutoValue;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableSet;
+import java.util.Queue;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Pipeline;
+import org.apache.beam.runners.core.construction.graph.ExecutableStage;
+import org.apache.beam.runners.core.construction.graph.FusedPipeline;
+import org.apache.beam.runners.core.construction.graph.ImmutableExecutableStage;
+import org.apache.beam.runners.core.construction.graph.OutputDeduplicator;
+import org.apache.beam.runners.core.construction.graph.OutputDeduplicator.DeduplicationResult;
+import org.apache.beam.runners.core.construction.graph.PipelineNode;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
+import org.apache.beam.runners.core.construction.graph.PipelineValidator;
+import org.apache.beam.runners.core.construction.graph.QueryablePipeline;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ComparisonChain;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.HashMultimap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Multimap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Fuses a {@link Pipeline} into some set of single-environment executable transforms. */
+// The use of NavigableSets everywhere provides consistent ordering but may be overkill for this
+// cause.
+@SuppressWarnings({
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
+public class SamzaPipelineFuser {
+  private static final Logger LOG = LoggerFactory.getLogger(SamzaPipelineFuser.class);
+
+  private final QueryablePipeline pipeline;
+  private final FusedPipeline fusedPipeline;
+
+  private SamzaPipelineFuser(Pipeline p) {
+    // Validate that the original pipeline is well-formed.
+    PipelineValidator.validate(p);
+    this.pipeline = QueryablePipeline.forPrimitivesIn(p.getComponents());
+    Set<PTransformNode> unfusedRootNodes = new LinkedHashSet<>();
+    NavigableSet<CollectionConsumer> rootConsumers = new TreeSet<>();
+    for (PTransformNode pTransformNode : pipeline.getRootTransforms()) {
+      // This will usually be a single node, the downstream of an Impulse, but may be of any size
+      DescendantConsumers descendants = getRootConsumers(pTransformNode);
+      unfusedRootNodes.addAll(descendants.getUnfusedNodes());
+      rootConsumers.addAll(descendants.getFusibleConsumers());
+    }
+    this.fusedPipeline =
+        fusePipeline(
+            unfusedRootNodes,
+            groupSiblings(rootConsumers),
+            ImmutableSet.copyOf(p.getRequirementsList()));
+  }
+
+  /**
+   * Fuses a {@link Pipeline} into a collection of {@link ExecutableStage ExecutableStages}.
+   *
+   * <p>This fuser expects each ExecutableStage to have exactly one input. This means that pipelines
+   * must be rooted at Impulse, or other runner-executed primitive transforms.
+   */
+  public static FusedPipeline fuse(Pipeline p) {
+    return new SamzaPipelineFuser(p).fusedPipeline;
+  }
+
+  /**
+   * Fuses a {@link Pipeline} into a collection of {@link ExecutableStage}.
+   *
+   * <p>The input is the initial collection of siblings sets which will be fused into {@link
+   * ExecutableStage stages}. A sibling in this context represents a pair of (PCollection,
+   * PTransform), where the PTransform consumes input elements on a per-element basis from the
+   * PCollection, represented by a {@link CollectionConsumer}. A sibling set is a collection of
+   * siblings which can execute within a single {@link ExecutableStage}, determined by {@link
+   * SamzaPCollectionFusers#isCompatible(PTransformNode, PTransformNode, QueryablePipeline)}.
+   *
+   * <p>While a pending sibling set exists:
+   *
+   * <ul>
+   *   <li>Retrieve a pending sibling set from the front of the queue.
+   *   <li>If the pending sibling set has already been created, continue. Each materialized {@link
+   *       PTransformNode} can be consumed by any number of {@link ExecutableStage stages}, but each
+   *       {@link PTransformNode} may only be present in a single stage rooted at a single {@link
+   *       PCollectionNode}, otherwise it will process elements of that {@link PCollectionNode}
+   *       multiple times.
+   *   <li>Create a {@link SamzaStageFuser} with those siblings as the initial consuming transforms
+   *       of the stage
+   *   <li>For each materialized {@link PCollectionNode}, find all of the descendant in-environment
+   *       consumers. See {@link #getDescendantConsumers(PCollectionNode)} for details.
+   *   <li>Construct all of the sibling sets from the descendant in-environment consumers, and add
+   *       them to the queue of sibling sets.
+   * </ul>
+   */
+  private FusedPipeline fusePipeline(
+      Collection<PTransformNode> initialUnfusedTransforms,
+      NavigableSet<NavigableSet<CollectionConsumer>> initialConsumers,
+      Set<String> requirements) {
+    Map<CollectionConsumer, ExecutableStage> consumedCollectionsAndTransforms = new HashMap<>();
+    Set<ExecutableStage> stages = new LinkedHashSet<>();
+    Set<PTransformNode> unfusedTransforms = new LinkedHashSet<>(initialUnfusedTransforms);
+
+    Queue<Set<CollectionConsumer>> pendingSiblingSets = new ArrayDeque<>(initialConsumers);
+    while (!pendingSiblingSets.isEmpty()) {
+      // Only introduce new PCollection consumers. Not performing this introduces potential
+      // duplicate paths through the pipeline.
+      Set<CollectionConsumer> candidateSiblings = pendingSiblingSets.poll();
+      Set<CollectionConsumer> siblingSet =
+          Sets.difference(candidateSiblings, consumedCollectionsAndTransforms.keySet());
+      checkState(
+          siblingSet.equals(candidateSiblings) || siblingSet.isEmpty(),
+          "Inconsistent collection of siblings reported for a %s. Initial attempt missed %s",
+          PCollectionNode.class.getSimpleName(),
+          siblingSet);
+      if (siblingSet.isEmpty()) {
+        LOG.debug("Filtered out duplicate stage root {}", candidateSiblings);
+        continue;
+      }
+      // Create the stage with these siblings as the initial consuming transforms
+      ExecutableStage stage = fuseSiblings(siblingSet);
+      // Mark each of the root transforms of the stage as consuming the input PCollection, so we
+      // don't place them in multiple stages.
+      for (CollectionConsumer sibling : siblingSet) {
+        consumedCollectionsAndTransforms.put(sibling, stage);
+      }
+      stages.add(stage);
+      for (PCollectionNode materializedOutput : stage.getOutputPCollections()) {
+        // Get all of the descendant consumers of each materialized PCollection, and add them to the
+        // queue of pending siblings.
+        DescendantConsumers descendantConsumers = getDescendantConsumers(materializedOutput);
+        unfusedTransforms.addAll(descendantConsumers.getUnfusedNodes());
+        NavigableSet<NavigableSet<CollectionConsumer>> siblings =
+            groupSiblings(descendantConsumers.getFusibleConsumers());
+
+        pendingSiblingSets.addAll(siblings);
+      }
+    }
+    // TODO: Figure out where to store this.
+    DeduplicationResult deduplicated =
+        OutputDeduplicator.ensureSingleProducer(pipeline, stages, unfusedTransforms);
+    // TODO: Stages can be fused with each other, if doing so does not introduce duplicate paths
+    // for an element to take through the Pipeline. Compatible siblings can generally be fused,
+    // as can compatible producers/consumers if a PCollection is only materialized once.
+    return FusedPipeline.of(
+        deduplicated.getDeduplicatedComponents(),
+        stages.stream()
+            .map(stage -> deduplicated.getDeduplicatedStages().getOrDefault(stage, stage))
+            .map(SamzaPipelineFuser::sanitizeDanglingPTransformInputs)
+            .collect(Collectors.toSet()),
+        Sets.union(
+            deduplicated.getIntroducedTransforms(),
+            unfusedTransforms.stream()
+                .map(
+                    transform ->
+                        deduplicated
+                            .getDeduplicatedTransforms()
+                            .getOrDefault(transform.getId(), transform))
+                .collect(Collectors.toSet())),
+        requirements);
+  }
+
+  private DescendantConsumers getRootConsumers(PTransformNode rootNode) {
+    checkArgument(
+        rootNode.getTransform().getInputsCount() == 0,
+        "Transform %s is not at the root of the graph (consumes %s)",
+        rootNode.getId(),
+        rootNode.getTransform().getInputsMap());
+    // li_trunk only: skip the check until we can handle environment_id of ReadRawKafka correctly
+    /*
+    checkArgument(
+        !pipeline.getEnvironment(rootNode).isPresent(),
+        "%s requires all root nodes to be runner-implemented %s or %s primitives, "
+            + "but transform %s executes in environment %s",
+        GreedyPipelineFuser.class.getSimpleName(),
+        PTransformTranslation.IMPULSE_TRANSFORM_URN,
+        PTransformTranslation.READ_TRANSFORM_URN,
+        rootNode.getId(),
+        pipeline.getEnvironment(rootNode));
+     */
+    Set<PTransformNode> unfused = new HashSet<>();
+    unfused.add(rootNode);
+    NavigableSet<CollectionConsumer> environmentNodes = new TreeSet<>();
+    // Walk down until the first environments are found, and fuse them as appropriate.
+    for (PCollectionNode output : pipeline.getOutputPCollections(rootNode)) {
+      DescendantConsumers descendants = getDescendantConsumers(output);
+      unfused.addAll(descendants.getUnfusedNodes());
+      environmentNodes.addAll(descendants.getFusibleConsumers());
+    }
+    return DescendantConsumers.of(unfused, environmentNodes);
+  }
+
+  /**
+   * Retrieve all descendant {@link PTransformNode PTransforms} which are executed within an {@link
+   * Environment}, such that there is a path between this input {@link PCollectionNode} and the
+   * descendant {@link PTransformNode} with no intermediate {@link PTransformNode} which executes
+   * within an environment.
+   *
+   * <p>This occurs as follows:
+   *
+   * <ul>
+   *   <li>For each consumer of the input {@link PCollectionNode}:
+   *       <ul>
+   *         <li>If that {@link PTransformNode} executes within an environment, add it to the
+   *             collection of descendants
+   *         <li>If that {@link PTransformNode} does not execute within an environment, for each
+   *             output {@link PCollectionNode} that that {@link PTransformNode} produces, add the
+   *             result of recursively applying this method to that {@link PCollectionNode}.
+   *       </ul>
+   * </ul>
+   *
+   * <p>As {@link PCollectionNode PCollections} output by a {@link PTransformNode} that executes
+   * within an {@link Environment} are not recursively inspected, {@link PTransformNode PTransforms}
+   * reachable only via a path including that node as an intermediate node cannot be returned as a
+   * descendant consumer of the original {@link PCollectionNode}.
+   */
+  private DescendantConsumers getDescendantConsumers(PCollectionNode inputPCollection) {
+    Set<PTransformNode> unfused = new HashSet<>();
+    NavigableSet<CollectionConsumer> downstreamConsumers = new TreeSet<>();
+    for (PTransformNode consumer : pipeline.getPerElementConsumers(inputPCollection)) {
+      if (pipeline.getEnvironment(consumer).isPresent()) {
+        // The base case: this descendant consumes elements from
+        downstreamConsumers.add(CollectionConsumer.of(inputPCollection, consumer));
+      } else {
+        LOG.debug(
+            "Adding {} {} to the set of runner-executed transforms",
+            PTransformNode.class.getSimpleName(),
+            consumer.getId());
+        unfused.add(consumer);
+        for (PCollectionNode output : pipeline.getOutputPCollections(consumer)) {
+          // Recurse to all of the ouput PCollections of this PTransform.
+          DescendantConsumers descendants = getDescendantConsumers(output);
+          unfused.addAll(descendants.getUnfusedNodes());
+          downstreamConsumers.addAll(descendants.getFusibleConsumers());
+        }
+      }
+    }
+    return DescendantConsumers.of(unfused, downstreamConsumers);
+  }
+
+  @AutoValue
+  abstract static class DescendantConsumers {
+    static DescendantConsumers of(
+        Set<PTransformNode> unfusible, NavigableSet<CollectionConsumer> fusible) {
+      return new org.apache.beam.runners.samza.fusers
+          .AutoValue_SamzaPipelineFuser_DescendantConsumers(unfusible, fusible);
+    }
+
+    abstract Set<PTransformNode> getUnfusedNodes();
+
+    abstract NavigableSet<CollectionConsumer> getFusibleConsumers();
+  }
+
+  /**
+   * The minimum requirement to fuse two {@link CollectionConsumer consumers} as siblings.
+   *
+   * <p>This is the minimum requirement for {@link PTransformNode transforms} to be siblings.
+   * Different {@link PTransformNode transforms} may have additional restrictions.
+   */
+  @AutoValue
+  abstract static class SiblingKey {
+    abstract PCollectionNode getInputCollection();
+
+    abstract Environment getEnv();
+  }
+
+  /**
+   * Produce the set of sets of {@link CollectionConsumer consumers} that can be fused into a single
+   * {@link ExecutableStage}. This identifies available siblings for sibling fusion.
+   *
+   * <p>For each set in the returned collection, each of {@link CollectionConsumer consumers}
+   * present consumes from the same {@link PCollection} and is compatible, as determined by {@link
+   * SamzaPCollectionFusers#isCompatible(PTransformNode, PTransformNode, QueryablePipeline)}.
+   *
+   * <p>Each input {@link CollectionConsumer} must have an associated {@link Environment}.
+   */
+  private NavigableSet<NavigableSet<CollectionConsumer>> groupSiblings(
+      NavigableSet<CollectionConsumer>
+          newConsumers /* Use a navigable set for consistent iteration order */) {
+    Multimap<SiblingKey, NavigableSet<CollectionConsumer>> compatibleConsumers =
+        HashMultimap.create();
+    // This is O(N**2) with the number of siblings we consider, which is generally the number of
+    // parallel consumers of a PCollection. This usually is unlikely to be high,
+    // but has potential to be a pretty significant slowdown.
+    for (CollectionConsumer newConsumer : newConsumers) {
+      SiblingKey key =
+          new org.apache.beam.runners.samza.fusers.AutoValue_SamzaPipelineFuser_SiblingKey(
+              newConsumer.consumedCollection(),
+              pipeline.getEnvironment(newConsumer.consumingTransform()).get());
+      boolean foundSiblings = false;
+      for (Set<CollectionConsumer> existingConsumers : compatibleConsumers.get(key)) {
+        if (existingConsumers.stream()
+            .allMatch(
+                // The two consume the same PCollection and can exist in the same stage.
+                collectionConsumer ->
+                    SamzaPCollectionFusers.isCompatible(
+                        collectionConsumer.consumingTransform(),
+                        newConsumer.consumingTransform(),
+                        pipeline))) {
+          existingConsumers.add(newConsumer);
+          foundSiblings = true;
+          break;
+        }
+      }
+      if (!foundSiblings) {
+        NavigableSet<CollectionConsumer> newConsumerSet = new TreeSet<>();
+        newConsumerSet.add(newConsumer);
+        compatibleConsumers.put(key, newConsumerSet);
+      }
+    }
+    // Order sibling sets by their least siblings. This is stable across the order siblings are
+    // generated, given stable IDs.
+    @SuppressWarnings("JdkObsolete")
+    NavigableSet<NavigableSet<CollectionConsumer>> orderedSiblings =
+        new TreeSet<>(Comparator.comparing(NavigableSet::first));
+    orderedSiblings.addAll(compatibleConsumers.values());
+    return orderedSiblings;
+  }
+
+  private ExecutableStage fuseSiblings(Set<CollectionConsumer> mutuallyCompatible) {
+    PCollectionNode rootCollection = mutuallyCompatible.iterator().next().consumedCollection();
+    return SamzaStageFuser.forGrpcPortRead(
+        pipeline,
+        rootCollection,
+        mutuallyCompatible.stream()
+            .map(CollectionConsumer::consumingTransform)
+            .collect(Collectors.toSet()));
+  }
+
+  private static ExecutableStage sanitizeDanglingPTransformInputs(ExecutableStage stage) {
+    /* Possible inputs to a PTransform can only be those which are:
+     * <ul>
+     *  <li>Explicit input PCollection to the stage
+     *  <li>Outputs of a PTransform within the same stage
+     *  <li>Timer PCollections
+     *  <li>Side input PCollections
+     *  <li>Explicit outputs from the stage
+     * </ul>
+     */
+    Set<String> possibleInputs = new HashSet<>();
+    possibleInputs.add(stage.getInputPCollection().getId());
+    possibleInputs.addAll(
+        stage.getOutputPCollections().stream()
+            .map(PCollectionNode::getId)
+            .collect(Collectors.toSet()));
+    possibleInputs.addAll(
+        stage.getSideInputs().stream()
+            .map(s -> s.collection().getId())
+            .collect(Collectors.toSet()));
+    possibleInputs.addAll(
+        stage.getTransforms().stream()
+            .flatMap(t -> t.getTransform().getOutputsMap().values().stream())
+            .collect(Collectors.toSet()));
+    Set<String> danglingInputs =
+        stage.getTransforms().stream()
+            .flatMap(t -> t.getTransform().getInputsMap().values().stream())
+            .filter(in -> !possibleInputs.contains(in))
+            .collect(Collectors.toSet());
+
+    ImmutableList.Builder<PTransformNode> pTransformNodesBuilder = ImmutableList.builder();
+    for (PTransformNode transformNode : stage.getTransforms()) {
+      PTransform transform = transformNode.getTransform();
+      Map<String, String> validInputs =
+          transform.getInputsMap().entrySet().stream()
+              .filter(e -> !danglingInputs.contains(e.getValue()))
+              .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+      if (!validInputs.equals(transform.getInputsMap())) {
+        // Dangling inputs found so recreate pTransform without the dangling inputs.
+        transformNode =
+            PipelineNode.pTransform(
+                transformNode.getId(),
+                transform.toBuilder().clearInputs().putAllInputs(validInputs).build());
+      }
+
+      pTransformNodesBuilder.add(transformNode);
+    }
+    ImmutableList<PTransformNode> pTransformNodes = pTransformNodesBuilder.build();
+    Components.Builder componentBuilder = stage.getComponents().toBuilder();
+    // Update the pTransforms in components.
+    componentBuilder
+        .clearTransforms()
+        .putAllTransforms(
+            pTransformNodes.stream()
+                .collect(Collectors.toMap(PTransformNode::getId, PTransformNode::getTransform)));
+    Map<String, PCollection> validPCollectionMap =
+        stage.getComponents().getPcollectionsMap().entrySet().stream()
+            .filter(e -> !danglingInputs.contains(e.getKey()))
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+    // Update pCollections in the components.
+    componentBuilder.clearPcollections().putAllPcollections(validPCollectionMap);
+
+    return ImmutableExecutableStage.of(
+        componentBuilder.build(),
+        stage.getEnvironment(),
+        stage.getInputPCollection(),
+        stage.getSideInputs(),
+        stage.getUserStates(),
+        stage.getTimers(),
+        pTransformNodes,
+        stage.getOutputPCollections(),
+        stage.getWireCoderSettings());
+  }
+
+  /**
+   * A ({@link PCollectionNode}, {@link PTransformNode}) pair representing a single {@link
+   * PTransformNode} consuming a single materialized {@link PCollectionNode}.
+   *
+   * <p>For convenience, {@link CollectionConsumer} implements {@link Comparable}. The natural
+   * ordering of {@link CollectionConsumer} is first by the IDs of the {@link
+   * #consumedCollection()}, then by the ID of the {@link #consumingTransform()}.
+   */
+  @AutoValue
+  abstract static class CollectionConsumer implements Comparable<CollectionConsumer> {
+    static CollectionConsumer of(PCollectionNode collection, PTransformNode consumer) {
+      return new org.apache.beam.runners.samza.fusers
+          .AutoValue_SamzaPipelineFuser_CollectionConsumer(collection, consumer);
+    }
+
+    abstract PCollectionNode consumedCollection();
+
+    abstract PTransformNode consumingTransform();
+
+    /**
+     * {@inheritDoc}.
+     *
+     * <p>The natural ordering of {@link CollectionConsumer} is first by the ID of the {@link
+     * #consumedCollection()}, then by the ID of the {@link #consumingTransform()}.
+     */
+    @Override
+    public int compareTo(CollectionConsumer that) {
+      return ComparisonChain.start()
+          .compare(this.consumedCollection().getId(), that.consumedCollection().getId())
+          .compare(this.consumingTransform().getId(), that.consumingTransform().getId())
+          .result();
+    }
+  }
+}

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/fusers/SamzaStageFuser.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/fusers/SamzaStageFuser.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.samza.fusers;
+
+import static org.apache.beam.runners.core.construction.graph.ExecutableStage.DEFAULT_WIRE_CODER_SETTINGS;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+
+import java.util.ArrayDeque;
+import java.util.LinkedHashSet;
+import java.util.Queue;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.runners.core.construction.graph.ExecutableStage;
+import org.apache.beam.runners.core.construction.graph.ImmutableExecutableStage;
+import org.apache.beam.runners.core.construction.graph.PipelineNode;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
+import org.apache.beam.runners.core.construction.graph.QueryablePipeline;
+import org.apache.beam.runners.core.construction.graph.SideInputReference;
+import org.apache.beam.runners.core.construction.graph.TimerReference;
+import org.apache.beam.runners.core.construction.graph.UserStateReference;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A factory class which produces an {@link ExecutableStage} by attempting to fuse all available
+ * {@link PCollectionNode PCollections} when it is constructed.
+ *
+ * <p>A {@link PCollectionNode} is fused into a stage if all of its consumers can be fused into the
+ * stage. A consumer can be fused into a stage if it is executed within the environment of that
+ * {@link ExecutableStage}, and receives only per-element inputs. To simplify integration for
+ * runners, this fuser specifically does not fuse PTransforms which consume side inputs or have user
+ * state, always making them the root of {@link ExecutableStage}.
+ *
+ * <p>A {@link PCollectionNode} with consumers that execute in an environment other than a stage is
+ * materialized, and its consumers execute in independent stages.
+ */
+@SuppressWarnings({
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
+public class SamzaStageFuser {
+  // TODO: Provide a way to merge in a compatible subgraph (e.g. one where all of the siblings
+  // consume a PCollection materialized by this subgraph and can be fused into it).
+  private static final Logger LOG = LoggerFactory.getLogger(SamzaStageFuser.class);
+
+  private SamzaStageFuser() {
+    // A Factory class, do not instantiate
+  }
+
+  /**
+   * Returns an {@link ExecutableStage} where the initial {@link PTransformNode PTransform} is a
+   * Remote gRPC Port Read, reading elements from the materialized {@link PCollectionNode
+   * PCollection}.
+   *
+   * @param initialNodes the initial set of sibling transforms to fuse into this node. All of the
+   *     transforms must consume the {@code inputPCollection} on a per-element basis, and must all
+   *     be mutually compatible.
+   */
+  public static ExecutableStage forGrpcPortRead(
+      QueryablePipeline pipeline,
+      PCollectionNode inputPCollection,
+      Set<PTransformNode> initialNodes) {
+    checkArgument(
+        !initialNodes.isEmpty(),
+        "%s must contain at least one %s.",
+        SamzaStageFuser.class.getSimpleName(),
+        PTransformNode.class.getSimpleName());
+    // Choose the environment from an arbitrary node. The initial nodes may not be empty for this
+    // subgraph to make any sense, there has to be at least one processor node
+    // (otherwise the stage is gRPC Read -> gRPC Write, which doesn't do anything).
+    Environment environment = getStageEnvironment(pipeline, initialNodes);
+
+    ImmutableSet.Builder<PTransformNode> fusedTransforms = ImmutableSet.builder();
+    fusedTransforms.addAll(initialNodes);
+
+    Set<SideInputReference> sideInputs = new LinkedHashSet<>();
+    Set<UserStateReference> userStates = new LinkedHashSet<>();
+    Set<TimerReference> timers = new LinkedHashSet<>();
+    Set<PCollectionNode> fusedCollections = new LinkedHashSet<>();
+    Set<PCollectionNode> materializedPCollections = new LinkedHashSet<>();
+
+    Queue<PCollectionNode> fusionCandidates = new ArrayDeque<>();
+    for (PTransformNode initialConsumer : initialNodes) {
+      fusionCandidates.addAll(pipeline.getOutputPCollections(initialConsumer));
+      sideInputs.addAll(pipeline.getSideInputs(initialConsumer));
+      userStates.addAll(pipeline.getUserStates(initialConsumer));
+      timers.addAll(pipeline.getTimers(initialConsumer));
+    }
+    while (!fusionCandidates.isEmpty()) {
+      PCollectionNode candidate = fusionCandidates.poll();
+      if (fusedCollections.contains(candidate) || materializedPCollections.contains(candidate)) {
+        // This should generally mean we get to a Flatten via multiple paths through the graph and
+        // we've already determined what to do with the output.
+        LOG.debug(
+            "Skipping fusion candidate {} because it is {} in this {}",
+            candidate,
+            fusedCollections.contains(candidate) ? "fused" : "materialized",
+            ExecutableStage.class.getSimpleName());
+        continue;
+      }
+      PCollectionFusibility fusibility =
+          canFuse(pipeline, candidate, environment, fusedCollections);
+      switch (fusibility) {
+        case MATERIALIZE:
+          materializedPCollections.add(candidate);
+          break;
+        case FUSE:
+          // All of the consumers of the candidate PCollection can be fused into this stage. Do so.
+          fusedCollections.add(candidate);
+          fusedTransforms.addAll(pipeline.getPerElementConsumers(candidate));
+          for (PTransformNode consumer : pipeline.getPerElementConsumers(candidate)) {
+            // The outputs of every transform fused into this stage must be either materialized or
+            // themselves fused away, so add them to the set of candidates.
+            fusionCandidates.addAll(pipeline.getOutputPCollections(consumer));
+            sideInputs.addAll(pipeline.getSideInputs(consumer));
+            userStates.addAll(pipeline.getUserStates(consumer));
+          }
+          break;
+        default:
+          throw new IllegalStateException(
+              String.format(
+                  "Unknown type of %s %s",
+                  PCollectionFusibility.class.getSimpleName(), fusibility));
+      }
+    }
+
+    return ImmutableExecutableStage.ofFullComponents(
+        pipeline.getComponents(),
+        environment,
+        inputPCollection,
+        sideInputs,
+        userStates,
+        timers,
+        fusedTransforms.build(),
+        materializedPCollections,
+        DEFAULT_WIRE_CODER_SETTINGS);
+  }
+
+  private static Environment getStageEnvironment(
+      QueryablePipeline pipeline, Set<PTransformNode> initialNodes) {
+    Supplier<IllegalArgumentException> missingEnv =
+        () ->
+            new IllegalArgumentException(
+                String.format(
+                    "%s must be populated on all %s in a %s",
+                    Environment.class.getSimpleName(),
+                    PTransformNode.class.getSimpleName(),
+                    SamzaStageFuser.class.getSimpleName()));
+    Environment env =
+        pipeline.getEnvironment(initialNodes.iterator().next()).orElseThrow(missingEnv);
+    initialNodes.forEach(
+        transformNode ->
+            checkArgument(
+                env.equals(pipeline.getEnvironment(transformNode).orElseThrow(missingEnv)),
+                "All %s in a %s must be the same. Got %s and %s",
+                Environment.class.getSimpleName(),
+                ExecutableStage.class.getSimpleName(),
+                env,
+                pipeline.getEnvironment(transformNode).get() /* will throw above if absent. */));
+    return env;
+  }
+
+  private static PCollectionFusibility canFuse(
+      QueryablePipeline pipeline,
+      PCollectionNode candidate,
+      Environment environment,
+      Set<PCollectionNode> fusedPCollections) {
+    for (PTransformNode consumer : pipeline.getPerElementConsumers(candidate)) {
+      if (anyInputsSideInputs(consumer, pipeline)
+          || !SamzaPCollectionFusers.canFuse(
+              consumer, environment, candidate, fusedPCollections, pipeline)) {
+        // Some of the consumers can't be fused into this subgraph, so the PCollection has to be
+        // materialized.
+        // TODO: Potentially, some of the consumers can be fused back into this stage later
+        // complicate the process, but at a high level, if a downstream stage can be fused into all
+        // of the stages that produce a PCollection it can be fused into all of those stages.
+        return PCollectionFusibility.MATERIALIZE;
+      }
+    }
+    // The PCollection also has to be materialized if it is used as a side input by any transform.
+    if (!pipeline.getSingletonConsumers(candidate).isEmpty()) {
+      return PCollectionFusibility.MATERIALIZE;
+    }
+    return PCollectionFusibility.FUSE;
+  }
+
+  private enum PCollectionFusibility {
+    MATERIALIZE,
+    FUSE,
+  }
+
+  private static boolean anyInputsSideInputs(PTransformNode consumer, QueryablePipeline pipeline) {
+    for (String inputPCollectionId : consumer.getTransform().getInputsMap().values()) {
+      RunnerApi.PCollection pCollection =
+          pipeline.getComponents().getPcollectionsMap().get(inputPCollectionId);
+      PCollectionNode pCollectionNode = PipelineNode.pCollection(inputPCollectionId, pCollection);
+      if (!pipeline.getSingletonConsumers(pCollectionNode).isEmpty()) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/fusers/package-info.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/fusers/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Internal implementation of the Beam runner for Apache Samza. */
+package org.apache.beam.runners.samza.fusers;


### PR DESCRIPTION
This is the first PR to support fusion optimizer on stateful ParDos.

This PR gives a way(a pipeline option) to enable the fusion optimizer on the ParDos that define user states. It doesn't try to fuse the transforms that define user timers. To support fusion optimizer for user timer scenario, we need to let `ParDoBoundMultiTranslator` pass the right/all key coders since the key coder is required/used while creating the `timerInternalsFactory`, which requires a code refactor. 

Notes:
I copied the Beam's default fuser classes `GreedyPipelineFuser`, `GreedyStageFuser`, and `GreedyPCollectionFusers`, and changed the logic to enable fusion for the ParDos having user states. And I renamed them as `SamzaPipelineFuser`, `SamzaStageFuser`, and `SamzaPCollectionFusers`.

Tests:
I have tested the changes by creating a snapshot locally and building a test pipeline with two stateful ParDos, verified the fusion worked.
```
2023-05-11 14:59:12 INFO [SamzaPipelineRunner] [li-samza-runner-job-invoker-0] Portable pipeline to run:
2023-05-11 14:59:12 INFO [SamzaPipelineRunner] [li-samza-runner-job-invoker-0] digraph {
    rankdir=LR
    0 [label="Read From Kafka/LiKafkaIO.Read/Raw Read\nbeam:transform:samza:li-kafka-raw-read:v1"]
    1 [label="Read From Kafka/LiKafkaIO.Read/Raw Read.out/EMBEDDED:0\nbeam:runner:executable_stage:v1"]
    0 -> 1 [style=solid label="Read From Kafka/LiKafkaIO.Read/Raw Read.out"]
}
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
