### PR TITLE
Support fusion on the ParDos with user states

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.10'
+    project.version = '2.45.11'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.10
-sdk_version=2.45.10
+version=2.45.11
+sdk_version=2.45.11
 
 javaVersion=1.8
 

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/FusedPipeline.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/FusedPipeline.java
@@ -35,7 +35,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
 /** A {@link Pipeline} which has been separated into collections of executable components. */
 @AutoValue
 public abstract class FusedPipeline {
-  static FusedPipeline of(
+  public static FusedPipeline of(
       Components components,
       Set<ExecutableStage> environmentalStages,
       Set<PTransformNode> runnerStages,

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/OutputDeduplicator.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/OutputDeduplicator.java
@@ -49,7 +49,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
-class OutputDeduplicator {
+public class OutputDeduplicator {
 
   /**
    * Ensure that no {@link PCollection} output by any of the {@code stages} or {@code
@@ -59,7 +59,7 @@ class OutputDeduplicator {
    * rewritten to produce a partial {@link PCollection}, which are then flattened together via an
    * introduced Flatten node which produces the original output.
    */
-  static DeduplicationResult ensureSingleProducer(
+  public static DeduplicationResult ensureSingleProducer(
       QueryablePipeline pipeline,
       Collection<ExecutableStage> stages,
       Collection<PTransformNode> unfusedTransforms) {
@@ -145,7 +145,7 @@ class OutputDeduplicator {
   }
 
   @AutoValue
-  abstract static class DeduplicationResult {
+  public abstract static class DeduplicationResult {
     private static DeduplicationResult of(
         RunnerApi.Components components,
         Set<PTransformNode> introducedTransforms,
@@ -155,13 +155,13 @@ class OutputDeduplicator {
           components, introducedTransforms, stages, unfused);
     }
 
-    abstract RunnerApi.Components getDeduplicatedComponents();
+    public abstract RunnerApi.Components getDeduplicatedComponents();
 
-    abstract Set<PTransformNode> getIntroducedTransforms();
+    public abstract Set<PTransformNode> getIntroducedTransforms();
 
-    abstract Map<ExecutableStage, ExecutableStage> getDeduplicatedStages();
+    public abstract Map<ExecutableStage, ExecutableStage> getDeduplicatedStages();
 
-    abstract Map<String, PTransformNode> getDeduplicatedTransforms();
+    public abstract Map<String, PTransformNode> getDeduplicatedTransforms();
   }
 
   private static PTransform createFlattenOfPartials(

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineOptions.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineOptions.java
@@ -164,6 +164,13 @@ public interface SamzaPipelineOptions extends PipelineOptions {
 
   void setExecutorServiceForProcessElement(ExecutorService executorService);
 
+  @Description(
+      "The fusion optimizer that the Samza runner use to optimize its pipeline. The value of this property is the fully-qualified name of a Java class that follows the implementation of GreedyPipelineFuser. Used only in portable mode.")
+  @Default.String("org.apache.beam.runners.core.construction.graph.GreedyPipelineFuser")
+  String getPipelineFuser();
+
+  void setPipelineFuser(String fuserClass);
+
   class ProcessElementExecutorServiceFactory implements DefaultValueFactory<ExecutorService> {
 
     @Override


### PR DESCRIPTION
This PR gives a way(a pipeline option `setPipelineFuser`) to let the end user enable the fusion optimizer on the ParDos that define user states. 

Tests:

I have tested the changes by creating a snapshot locally and building a test pipeline with two stateful ParDos, verified the fusion worked.

before fusion:
```
2023-05-31 15:46:49 INFO [SamzaPipelineRunner] [li-samza-runner-job-invoker-0] Portable pipeline to run:
2023-05-31 15:46:49 INFO [SamzaPipelineRunner] [li-samza-runner-job-invoker-0] digraph {
    rankdir=LR
    0 [label="Read From Kafka/LiKafkaIO.Read/Raw Read\nbeam:transform:samza:li-kafka-raw-read:v1"]
    1 [label="Read From Kafka/LiKafkaIO.Read/Raw Read.out/EMBEDDED:0\nbeam:runner:executable_stage:v1"]
    0 -> 1 [style=solid label="Read From Kafka/LiKafkaIO.Read/Raw Read.out"]
    2 [label="Read From Kafka/Remove Kafka Metadata/ParMultiDo(Anonymous).output/EMBEDDED:0\nbeam:runner:executable_stage:v1"]
    1 -> 2 [style=solid label="Read From Kafka/Remove Kafka Metadata/ParMultiDo(Anonymous).output"]
    3 [label="First stateful ParDo/ParMultiDo(Anonymous).output/EMBEDDED:0\nbeam:runner:executable_stage:v1"]
    2 -> 3 [style=solid label="First stateful ParDo/ParMultiDo(Anonymous).output"]
}

```
after fusion:
```
2023-05-31 15:45:54 INFO [SamzaPipelineRunner] [li-samza-runner-job-invoker-0] Portable pipeline to run:
2023-05-31 15:45:54 INFO [SamzaPipelineRunner] [li-samza-runner-job-invoker-0] digraph {
    rankdir=LR
    0 [label="Read From Kafka/LiKafkaIO.Read/Raw Read\nbeam:transform:samza:li-kafka-raw-read:v1"]
    1 [label="Read From Kafka/LiKafkaIO.Read/Raw Read.out/EMBEDDED:0\nbeam:runner:executable_stage:v1"]
    0 -> 1 [style=solid label="Read From Kafka/LiKafkaIO.Read/Raw Read.out"]
}
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
