### PR TITLE
Invoke RunnerPipelineOptionsFactory by checking stack trace

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.13'
+    project.version = '2.45.14'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.13
-sdk_version=2.45.13
+version=2.45.14
+sdk_version=2.45.14
 
 javaVersion=1.8
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/RunnerPipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/RunnerPipelineOptionsFactory.java
@@ -42,4 +42,27 @@ public interface RunnerPipelineOptionsFactory {
     final Iterator<Registrar> factories = ServiceLoader.load(Registrar.class).iterator();
     return factories.hasNext() ? Iterators.getOnlyElement(factories).create() : null;
   }
+
+  /** Helper method to find the caller {@link RunnerPipelineOptionsFactory} in the current stack. */
+  static @Initialized @Nullable Class<? extends RunnerPipelineOptionsFactory> findFactoryCaller() {
+    final StackTraceElement[] trace = new Throwable().getStackTrace();
+    for (StackTraceElement elem : trace) {
+      String className = elem.getClassName();
+
+      try {
+        Class<?> clazz = Class.forName(className);
+        if (RunnerPipelineOptionsFactory.class != clazz
+            && RunnerPipelineOptionsFactory.class.isAssignableFrom(clazz)) {
+          @SuppressWarnings("unchecked")
+          Class<? extends RunnerPipelineOptionsFactory> factoryClazz =
+              (Class<? extends RunnerPipelineOptionsFactory>) clazz;
+          return factoryClazz;
+        }
+
+      } catch (ClassNotFoundException e) {
+        // ignore
+      }
+    }
+    return null;
+  }
 }


### PR DESCRIPTION
Previously we introduced the RunnerPipelineOptionsFactory to load LInkedIn runner-specific factories from runtime module. The invocation was decided by a threadlocal boolean variable. This allows us to use open source PipelineOptionsFactory across different runners. However, I ran into problems when trying to use the specific factory, e.g. SamzaRunnerPipelineOptionsFactory directly. When using it directly, we don't have a way to set the boolean flag, which will cause the confusion in the logic. To solve this issue, we replace the check by finding out whether the Runner factory is in the stack trace. If the runner factory is already invoked, we will not invoke again.

Tested in a unit test but not able to check in due to the registrar will be loaded for all other tests. Attach it in the pr.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
