### PR TITLE
Explicitly force execution order for some required modules

### DIFF
--- a/auto-elr/build.gradle
+++ b/auto-elr/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   implementation project(":runners:portability:java")
 
   implementation project(":sdks:java:core")
+  implementation project(":sdks:java:extensions:google-cloud-platform-core")
   implementation project(":sdks:java:extensions:join-library")
   implementation project(":sdks:java:extensions:sorter")
   implementation project(":sdks:java:extensions:sql")
@@ -45,6 +46,7 @@ dependencies {
   implementation project(":sdks:java:io:hadoop-file-system")
   implementation project(":sdks:java:io:hadoop-format")
   implementation project(":sdks:java:io:kafka")
+  implementation project(":sdks:java:io:mongodb")
 }
 
 // Enforce the publish task of this auto-elr module to be executed after other modules
@@ -63,6 +65,7 @@ tasks.all { task ->
     task.mustRunAfter(":runners:portability:java:publishMavenJavaPublicationToLinkedin.jfrog.httpsRepository")
 
     task.mustRunAfter(":sdks:java:core:publishMavenJavaPublicationToLinkedin.jfrog.httpsRepository")
+    task.mustRunAfter(":sdks:java:extensions:google-cloud-platform-core:publishMavenJavaPublicationToLinkedin.jfrog.httpsRepository")
     task.mustRunAfter(":sdks:java:extensions:join-library:publishMavenJavaPublicationToLinkedin.jfrog.httpsRepository")
     task.mustRunAfter(":sdks:java:extensions:sorter:publishMavenJavaPublicationToLinkedin.jfrog.httpsRepository")
     task.mustRunAfter(":sdks:java:extensions:sql:publishMavenJavaPublicationToLinkedin.jfrog.httpsRepository")
@@ -70,5 +73,6 @@ tasks.all { task ->
     task.mustRunAfter(":sdks:java:io:hadoop-file-system:publishMavenJavaPublicationToLinkedin.jfrog.httpsRepository")
     task.mustRunAfter(":sdks:java:io:hadoop-format:publishMavenJavaPublicationToLinkedin.jfrog.httpsRepository")
     task.mustRunAfter(":sdks:java:io:kafka:publishMavenJavaPublicationToLinkedin.jfrog.httpsRepository")
+    task.mustRunAfter(":sdks:java:io:mongodb:publishMavenJavaPublicationToLinkedin.jfrog.httpsRepository")
   }
 }

--- a/auto-elr/build.gradle
+++ b/auto-elr/build.gradle
@@ -47,6 +47,7 @@ dependencies {
   implementation project(":sdks:java:io:hadoop-format")
   implementation project(":sdks:java:io:kafka")
   implementation project(":sdks:java:io:mongodb")
+  implementation project(":sdks:java:io:google-cloud-platform")
 }
 
 // Enforce the publish task of this auto-elr module to be executed after other modules
@@ -74,5 +75,6 @@ tasks.all { task ->
     task.mustRunAfter(":sdks:java:io:hadoop-format:publishMavenJavaPublicationToLinkedin.jfrog.httpsRepository")
     task.mustRunAfter(":sdks:java:io:kafka:publishMavenJavaPublicationToLinkedin.jfrog.httpsRepository")
     task.mustRunAfter(":sdks:java:io:mongodb:publishMavenJavaPublicationToLinkedin.jfrog.httpsRepository")
+    task.mustRunAfter(":sdks:java:io:google-cloud-platform:publishMavenJavaPublicationToLinkedin.jfrog.httpsRepository")
   }
 }


### PR DESCRIPTION
Found one ELR job failed with below error, so adding these missing modules explicitly in the rule:
```
* What went wrong:
Execution failed for task ':resolveDependencies'.
> Could not resolve all dependencies for configuration ':detachedConfiguration14'.
   > Could not resolve com.linkedin.beam:beam-sdks-java-extensions-google-cloud-platform-core:200.45.13.101.
     Required by:
         project : > com.linkedin.beam:beam-auto-elr:200.45.13.101 > com.linkedin.beam:beam-runners-flink-1.15:200.45.13.101
         project : > com.linkedin.beam:beam-auto-elr:200.45.13.101 > com.linkedin.beam:beam-runners-flink-1.16:200.45.13.101
         project : > com.linkedin.beam:beam-auto-elr:200.45.13.101 > com.linkedin.beam:beam-runners-spark:200.45.13.101
         project : > com.linkedin.beam:beam-auto-elr:200.45.13.101 > com.linkedin.beam:beam-runners-spark-3:200.45.13.101
         project : > com.linkedin.beam:beam-auto-elr:200.45.13.101 > com.linkedin.beam:beam-sdks-java-extensions-sql:200.45.13.101
      > Could not resolve com.linkedin.beam:beam-sdks-java-extensions-google-cloud-platform-core:200.45.13.101.
         > Could not get resource 'https://repo.spring.io/plugins-release/com/linkedin/beam/beam-sdks-java-extensions-google-cloud-platform-core/200.45.13.101/beam-sdks-java-extensions-google-cloud-platform-core-200.45.13.101.pom'.
            > Could not GET 'https://repo.spring.io/plugins-release/com/linkedin/beam/beam-sdks-java-extensions-google-cloud-platform-core/200.45.13.101/beam-sdks-java-extensions-google-cloud-platform-core-200.45.13.101.pom'. Received status code 401 from server: 
   > Could not resolve com.linkedin.beam:beam-sdks-java-io-google-cloud-platform:200.45.13.101.
     Required by:
         project : > com.linkedin.beam:beam-auto-elr:200.45.13.101 > com.linkedin.beam:beam-sdks-java-extensions-sql:200.45.13.101
      > Could not resolve com.linkedin.beam:beam-sdks-java-io-google-cloud-platform:200.45.13.101.
         > Could not get resource 'https://repo.spring.io/plugins-release/com/linkedin/beam/beam-sdks-java-io-google-cloud-platform/200.45.13.101/beam-sdks-java-io-google-cloud-platform-200.45.13.101.pom'.
            > Could not GET 'https://repo.spring.io/plugins-release/com/linkedin/beam/beam-sdks-java-io-google-cloud-platform/200.45.13.101/beam-sdks-java-io-google-cloud-platform-200.45.13.101.pom'. Received status code 401 from server: 
   > Could not resolve com.linkedin.beam:beam-sdks-java-io-mongodb:200.45.13.101.
     Required by:
         project : > com.linkedin.beam:beam-auto-elr:200.45.13.101 > com.linkedin.beam:beam-sdks-java-extensions-sql:200.45.13.101
      > Could not resolve com.linkedin.beam:beam-sdks-java-io-mongodb:200.45.13.101.
         > Could not get resource 'https://repo.spring.io/plugins-release/com/linkedin/beam/beam-sdks-java-io-mongodb/200.45.13.101/beam-sdks-java-io-mongodb-200.45.13.101.pom'.
            > Could not GET 'https://repo.spring.io/plugins-release/com/linkedin/beam/beam-sdks-java-io-mongodb/200.45.13.101/beam-sdks-java-io-mongodb-200.45.13.101.pom'. Received status code 401 from server: 

```

#### Tests

- https://dependency-portal.tools.corp.linkedin.com/#/elr/details/125408

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.


