### PR TITLE
Allows customization in the Flink State binding

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.19'
+    project.version = '2.45.20'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.19
-sdk_version=2.45.19
+version=2.45.20
+sdk_version=2.45.20
 
 javaVersion=1.8
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -63,6 +63,7 @@ import org.apache.beam.runners.flink.translation.utils.CheckpointStats;
 import org.apache.beam.runners.flink.translation.utils.Workarounds;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.stableinput.BufferingDoFnRunner;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkBroadcastStateInternals;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkStateBinders;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkStateInternals;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StructuredCoder;
@@ -552,7 +553,7 @@ public class DoFnOperator<InputT, OutputT>
       if (doFn != null) {
         DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
         FlinkStateInternals.EarlyBinder earlyBinder =
-            new FlinkStateInternals.EarlyBinder(getKeyedStateBackend(), serializedOptions);
+            FlinkStateBinders.getEarlyBinder(getKeyedStateBackend(), serializedOptions, stepName);
         for (DoFnSignature.StateDeclaration value : signature.stateDeclarations().values()) {
           StateSpec<?> spec =
               (StateSpec<?>) signature.stateDeclarations().get(value.id()).field().get(doFn);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateBinders.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateBinders.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers.streaming.state;
+
+import java.util.ServiceLoader;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+
+/**
+ * LinkedIn-only: allow custom configuration of {@link
+ * org.apache.flink.api.common.state.StateDescriptor} during the Beam state binding.
+ */
+@SuppressWarnings({"rawtypes", "nullness"})
+public class FlinkStateBinders {
+  /** An interface that allows custom {@link org.apache.beam.sdk.state.StateBinder}. */
+  public interface Registrar {
+    FlinkStateInternals.EarlyBinder getEarlyBinder(
+        KeyedStateBackend keyedStateBackend,
+        SerializablePipelineOptions pipelineOptions,
+        String stepName);
+  }
+
+  private static final Registrar REGISTRAR =
+      Iterables.getOnlyElement(ServiceLoader.load(Registrar.class), null);
+
+  /**
+   * Returns {@link
+   * org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkStateInternals.EarlyBinder}
+   * that creates the user states from the Flink state backend.
+   */
+  public static FlinkStateInternals.EarlyBinder getEarlyBinder(
+      KeyedStateBackend keyedStateBackend,
+      SerializablePipelineOptions pipelineOptions,
+      String stepName) {
+    if (REGISTRAR != null) {
+      return REGISTRAR.getEarlyBinder(keyedStateBackend, pipelineOptions, stepName);
+    } else {
+      return new FlinkStateInternals.EarlyBinder(keyedStateBackend, pipelineOptions);
+    }
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateBinders.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateBinders.java
@@ -22,10 +22,7 @@ import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 
-/**
- * LinkedIn-only: allow custom configuration of {@link
- * org.apache.flink.api.common.state.StateDescriptor} during the Beam state binding.
- */
+/** LinkedIn-only: allow customization in Beam state binding. */
 @SuppressWarnings({"rawtypes", "nullness"})
 public class FlinkStateBinders {
   /** An interface that allows custom {@link org.apache.beam.sdk.state.StateBinder}. */

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -1713,9 +1713,11 @@ public class FlinkStateInternals<K> implements StateInternals {
       return null;
     }
 
-    protected <NamespaceT, StateT extends org.apache.flink.api.common.state.State, T> StateT getOrCreateKeyedState(
-        TypeSerializer<NamespaceT> namespaceSerializer, StateDescriptor<StateT, T> stateDescriptor)
-        throws Exception {
+    protected <NamespaceT, StateT extends org.apache.flink.api.common.state.State, T>
+        StateT getOrCreateKeyedState(
+            TypeSerializer<NamespaceT> namespaceSerializer,
+            StateDescriptor<StateT, T> stateDescriptor)
+            throws Exception {
       return (StateT) keyedStateBackend.getOrCreateKeyedState(namespaceSerializer, stateDescriptor);
     }
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -1581,7 +1581,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     @Override
     public <T> ValueState<T> bindValue(String id, StateSpec<ValueState<T>> spec, Coder<T> coder) {
       try {
-        keyedStateBackend.getOrCreateKeyedState(
+        getOrCreateKeyedState(
             StringSerializer.INSTANCE,
             new ValueStateDescriptor<>(id, new CoderTypeSerializer<>(coder, pipelineOptions)));
       } catch (Exception e) {
@@ -1594,7 +1594,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     @Override
     public <T> BagState<T> bindBag(String id, StateSpec<BagState<T>> spec, Coder<T> elemCoder) {
       try {
-        keyedStateBackend.getOrCreateKeyedState(
+        getOrCreateKeyedState(
             StringSerializer.INSTANCE,
             new ListStateDescriptor<>(id, new CoderTypeSerializer<>(elemCoder, pipelineOptions)));
       } catch (Exception e) {
@@ -1607,7 +1607,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     @Override
     public <T> SetState<T> bindSet(String id, StateSpec<SetState<T>> spec, Coder<T> elemCoder) {
       try {
-        keyedStateBackend.getOrCreateKeyedState(
+        getOrCreateKeyedState(
             StringSerializer.INSTANCE,
             new MapStateDescriptor<>(
                 id,
@@ -1626,7 +1626,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         Coder<KeyT> mapKeyCoder,
         Coder<ValueT> mapValueCoder) {
       try {
-        keyedStateBackend.getOrCreateKeyedState(
+        getOrCreateKeyedState(
             StringSerializer.INSTANCE,
             new MapStateDescriptor<>(
                 id,
@@ -1642,7 +1642,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public <T> OrderedListState<T> bindOrderedList(
         String id, StateSpec<OrderedListState<T>> spec, Coder<T> elemCoder) {
       try {
-        keyedStateBackend.getOrCreateKeyedState(
+        getOrCreateKeyedState(
             StringSerializer.INSTANCE,
             new ListStateDescriptor<>(
                 id,
@@ -1671,7 +1671,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         Coder<AccumT> accumCoder,
         Combine.CombineFn<InputT, AccumT, OutputT> combineFn) {
       try {
-        keyedStateBackend.getOrCreateKeyedState(
+        getOrCreateKeyedState(
             StringSerializer.INSTANCE,
             new ValueStateDescriptor<>(id, new CoderTypeSerializer<>(accumCoder, pipelineOptions)));
       } catch (Exception e) {
@@ -1688,7 +1688,7 @@ public class FlinkStateInternals<K> implements StateInternals {
             Coder<AccumT> accumCoder,
             CombineWithContext.CombineFnWithContext<InputT, AccumT, OutputT> combineFn) {
       try {
-        keyedStateBackend.getOrCreateKeyedState(
+        getOrCreateKeyedState(
             StringSerializer.INSTANCE,
             new ValueStateDescriptor<>(id, new CoderTypeSerializer<>(accumCoder, pipelineOptions)));
       } catch (Exception e) {
@@ -1701,7 +1701,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public WatermarkHoldState bindWatermark(
         String id, StateSpec<WatermarkHoldState> spec, TimestampCombiner timestampCombiner) {
       try {
-        keyedStateBackend.getOrCreateKeyedState(
+        getOrCreateKeyedState(
             VoidNamespaceSerializer.INSTANCE,
             new MapStateDescriptor<>(
                 "watermark-holds",
@@ -1711,6 +1711,12 @@ public class FlinkStateInternals<K> implements StateInternals {
         throw new RuntimeException(e);
       }
       return null;
+    }
+
+    protected <NamespaceT, StateT extends org.apache.flink.api.common.state.State, T> StateT getOrCreateKeyedState(
+        TypeSerializer<NamespaceT> namespaceSerializer, StateDescriptor<StateT, T> stateDescriptor)
+        throws Exception {
+      return (StateT) keyedStateBackend.getOrCreateKeyedState(namespaceSerializer, stateDescriptor);
     }
   }
 }


### PR DESCRIPTION
This patch allows LinkedIn to extend the state binding in FlinkStateInternals to support configs such as TTL. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
