### PR TITLE
Context Propagation: KV

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/KV.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/KV.java
@@ -18,8 +18,12 @@
 package org.apache.beam.sdk.values;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.GroupByKey;
@@ -38,7 +42,7 @@ import org.checkerframework.dataflow.qual.Pure;
  * @param <K> the type of the key
  * @param <V> the type of the value
  */
-public class KV<K, V> implements Serializable {
+public class KV<K, V> implements Serializable, Traceable {
   /** Returns a {@link KV} with the given key and value. */
   public static <K, V> KV<K, V> of(K key, V value) {
     return new KV<>(key, value);
@@ -56,10 +60,22 @@ public class KV<K, V> implements Serializable {
     return value;
   }
 
+  @Override
+  public Map<String, String> getW3cTraceContext() {
+    return w3cTraceContext;
+  }
+
+  @Override
+  public List<Map<String, String>> getW3cLinkedContext() {
+    return w3cLinkedContext;
+  }
+
   /////////////////////////////////////////////////////////////////////////////
 
   final K key;
   final V value;
+  final Map<String, String> w3cTraceContext = new HashMap<>();
+  final List<Map<String, String>> w3cLinkedContext = new ArrayList<>();
 
   private KV(K key, V value) {
     this.key = key;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Traceable.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Traceable.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.values;
+
+import java.util.List;
+import java.util.Map;
+
+public interface Traceable {
+
+  Map<String, String> getW3cTraceContext();
+
+  List<Map<String, String>> getW3cLinkedContext();
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/KvCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/KvCoderTest.java
@@ -105,7 +105,7 @@ public class KvCoderTest {
    * org.apache.beam.sdk.coders.PrintBase64Encodings}.
    */
   private static final List<String> TEST_ENCODINGS =
-      Arrays.asList("AP____8P", "BWhlbGxvAA", "B2dvb2RieWX_____Bw");
+      Arrays.asList("AAAAAAD_____Dw", "AAAAAAVoZWxsbwA", "AAAAAAdnb29kYnll_____wc");
 
   @Test
   public void testWireFormatEncode() throws Exception {


### PR DESCRIPTION
Demonstrates how context could be added to Beam's KV object type for the purpose of propagating W3C Trace Context between PTransforms. This is only a proof of concept so far; possible this will be implemented using Byte Buddy and a java agent instead.
