### PR TITLE
Introduce CachedToStringMetricKey and CachedToStringMetricName for Improved Performance

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.26'
+    project.version = '2.45.27'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.26
-sdk_version=2.45.26
+version=2.45.27
+sdk_version=2.45.27
 
 javaVersion=1.8
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/CachedToStringMetricKey.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/CachedToStringMetricKey.java
@@ -1,0 +1,52 @@
+package org.apache.beam.sdk.metrics;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+
+/**
+ * This class is a wrapper around a {@link MetricKey} that caches its {@code toString()} value.
+ *
+ * The primary goal is to improve performance by caching the result of {@code toString()}
+ * at construction, thereby reducing the overhead of repeated calls in performance-sensitive
+ * contexts.
+ *
+ * The {@code stepName()} method delegates to the underlying {@link MetricKey}, while
+ * the {@code metricName()} method now returns a {@link CachedToStringMetricName}, which
+ * similarly caches the result of its {@code toString()} method for improved efficiency.
+ */
+public class CachedToStringMetricKey extends MetricKey {
+  private final MetricKey metricKey;
+  private final CachedToStringMetricName cachedToStringMetricName;
+  private final String cachedToString;
+
+  public CachedToStringMetricKey(MetricKey metricKey) {
+    this.metricKey = metricKey;
+    this.cachedToStringMetricName = new CachedToStringMetricName(metricKey.metricName());
+    this.cachedToString = metricKey.toString();
+  }
+
+  @Override
+  public @Nullable String stepName() {
+    return metricKey.stepName();
+  }
+
+  @Override
+  public MetricName metricName() {
+    return cachedToStringMetricName;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    return metricKey.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return metricKey.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return cachedToString;
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/CachedToStringMetricName.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/CachedToStringMetricName.java
@@ -1,0 +1,49 @@
+package org.apache.beam.sdk.metrics;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+
+/**
+ * This class wraps around a {@link MetricName} and caches its {@code toString()} value.
+ *
+ * The purpose of this class is to optimize repeated calls to {@code toString()} by
+ * caching the result upon construction. This reduces overhead in scenarios where
+ * the {@code toString()} method is frequently invoked.
+ *
+ * It delegates all other method calls (e.g., {@code getNamespace()}, {@code getName()})
+ * to the underlying {@link MetricName} instance.
+ */
+public class CachedToStringMetricName extends MetricName {
+  private final MetricName metricName;
+  private final String cachedToString;
+
+  public CachedToStringMetricName(MetricName metricName) {
+    this.metricName = metricName;
+    this.cachedToString = metricName.toString();
+  }
+
+  @Override
+  public String getNamespace() {
+    return metricName.getNamespace();
+  }
+
+  @Override
+  public String getName() {
+    return metricName.getName();
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    return metricName.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return metricName.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return cachedToString;
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricKey.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricKey.java
@@ -18,13 +18,14 @@
 package org.apache.beam.sdk.metrics;
 
 import com.google.auto.value.AutoValue;
-import com.google.auto.value.extension.memoized.Memoized;
 import java.io.Serializable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+
 /** Metrics are keyed by the step name they are associated with and the name of the metric. */
+@SuppressWarnings("AutoValueFinalMethods")
 @Experimental(Kind.METRICS)
 @AutoValue
 public abstract class MetricKey implements Serializable {
@@ -36,12 +37,11 @@ public abstract class MetricKey implements Serializable {
   public abstract MetricName metricName();
 
   @Override
-  @Memoized
   public String toString() {
     return stepName() + ":" + metricName();
   }
 
   public static MetricKey create(@Nullable String stepName, MetricName metricName) {
-    return new AutoValue_MetricKey(stepName, metricName);
+    return new CachedToStringMetricKey(new AutoValue_MetricKey(stepName, metricName));
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricName.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricName.java
@@ -20,7 +20,6 @@ package org.apache.beam.sdk.metrics;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 
 import com.google.auto.value.AutoValue;
-import com.google.auto.value.extension.memoized.Memoized;
 import java.io.Serializable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
@@ -43,7 +42,6 @@ public abstract class MetricName implements Serializable {
   public abstract String getName();
 
   @Override
-  @Memoized
   public String toString() {
     return getNamespace() + ":" + getName();
   }
@@ -51,12 +49,12 @@ public abstract class MetricName implements Serializable {
   public static MetricName named(String namespace, String name) {
     checkArgument(!Strings.isNullOrEmpty(namespace), "Metric namespace must be non-empty");
     checkArgument(!Strings.isNullOrEmpty(name), "Metric name must be non-empty");
-    return new AutoValue_MetricName(namespace, name);
+    return new CachedToStringMetricName(new AutoValue_MetricName(namespace, name));
   }
 
   public static MetricName named(Class<?> namespace, String name) {
     checkArgument(namespace != null, "Metric namespace must be non-null");
     checkArgument(!Strings.isNullOrEmpty(name), "Metric name must be non-empty");
-    return new AutoValue_MetricName(namespace.getName(), name);
+    return new CachedToStringMetricName(new AutoValue_MetricName(namespace.getName(), name));
   }
 }


### PR DESCRIPTION
### PR Description:  
**Introduce `CachedToStringMetricKey` and `CachedToStringMetricName` for Improved Performance**

#### Summary:
This PR introduces two new classes, `CachedToStringMetricKey` and `CachedToStringMetricName`, which cache the result of the `toString()` method to improve performance in scenarios where `toString()` is frequently called.

#### Key Changes:
- **CachedToStringMetricKey**: A wrapper around `MetricKey` that caches the `toString()` result upon construction, reducing overhead from repeated `toString()` calls in performance-sensitive areas.
- **CachedToStringMetricName**: Similar to `CachedToStringMetricKey`, this class wraps around `MetricName` and caches its `toString()` value for efficiency, while still delegating all other methods to the original `MetricName`.
- **`equals()` and `hashCode()` Overrides**: To ensure consistency in collections, `equals()` and `hashCode()` were overridden to delegate these comparisons to the underlying `MetricName` and `MetricKey` instances. This ensures correct behavior when these objects are used as keys in maps.
- **Handling `@Nullable` Parameters**: Updated the `equals()` method to handle `@Nullable` parameters correctly, following Java’s contract for `equals()` and ensuring compatibility with null comparisons.
- Replaced `@Memoized` in `MetricKey` and `MetricName` with the new cached classes, removing the overhead caused by the `@Memoized` pattern.

#### Motivation:
The use of `@Memoized` for the `toString()` method in the auto-generated `MetricKey` and `MetricName` classes introduces unnecessary overhead due to its thread-safe memoization pattern, which includes additional synchronization logic. This pattern creates a `transient volatile String toString` field and performs a synchronized check with every `toString()` call. This can degrade performance, especially when `toString()` is frequently invoked in performance-sensitive parts of the metrics system.

By caching the `toString()` value at construction, we eliminate this overhead, leading to significant performance improvements. Benchmarks have shown that even directly computing `toString()` is faster than the memoized implementation. The new approach optimizes for frequent `toString()` invocations without the cost of synchronization.

#### Changes:
- Removed `@Memoized` annotations from `MetricKey` and `MetricName`.
- Updated `MetricKey.create()` to use `CachedToStringMetricKey` and `MetricName` construction to use `CachedToStringMetricName`.
- Added new classes to handle caching logic for `toString()` and ensured consistent usage across the codebase to avoid potential issues with mixed types in collections.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
