### PR TITLE
Offload Beam Samza Metrics Update to Background Threads to Improve Performance

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.27'
+    project.version = '2.45.28'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.27
-sdk_version=2.45.27
+version=2.45.28
+sdk_version=2.45.28
 
 javaVersion=1.8
 

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/metrics/SamzaMetricsContainer.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/metrics/SamzaMetricsContainer.java
@@ -20,7 +20,12 @@ package org.apache.beam.runners.samza.metrics;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.beam.runners.core.metrics.DefaultMetricResults;
 import org.apache.beam.runners.core.metrics.DistributionData;
@@ -34,6 +39,7 @@ import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricResult;
 import org.apache.beam.sdk.metrics.MetricResults;
 import org.apache.beam.sdk.metrics.MetricsContainer;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.samza.config.Config;
 import org.apache.samza.metrics.Counter;
 import org.apache.samza.metrics.Gauge;
@@ -53,24 +59,43 @@ public class SamzaMetricsContainer {
 
   private static final Logger LOG = LoggerFactory.getLogger(SamzaMetricsContainer.class);
   private static final String BEAM_METRICS_GROUP = "BeamMetrics";
-  // global metrics container is the default container that can be used in user threads
   public static final String GLOBAL_CONTAINER_STEP_NAME = "GLOBAL_METRICS";
   public static final String USE_SHORT_METRIC_NAMES_CONFIG =
       "beam.samza.metrics.useShortMetricNames";
   public static final String COMMIT_ALL_METRIC_UPDATES =
       "beam.samza.metrics.commitAllMetricUpdates";
+  public static final String DEFER_TO_EXECUTOR_CONFIG = "beam.samza.metrics.deferToExecutor";
+  public static final String METRIC_UPDATE_INTERVAL_SEC_CONFIG =
+      "beam.samza.metrics.updateIntervalSec";
 
   private final MetricsContainerStepMap metricsContainers = new MetricsContainerStepMap();
   private final MetricsRegistryMap metricsRegistry;
   private final boolean useShortMetricNames;
   private final boolean commitAllMetricUpdates;
+  private final boolean deferToExecutor;
+  private final Set<String> activeStepNames = ConcurrentHashMap.newKeySet();
+  // technically this doesn't need to be volatile, but needed to pass spotbugs check
+  private volatile boolean executorServiceStarted = false;
+  private ScheduledExecutorService executorService;
+  private ScheduledFuture<?> scheduledFuture;
+  private final long metricUpdateIntervalSec;
 
   public SamzaMetricsContainer(MetricsRegistryMap metricsRegistry, Config config) {
     this.metricsRegistry = metricsRegistry;
     this.useShortMetricNames = config.getBoolean(USE_SHORT_METRIC_NAMES_CONFIG, false);
     this.commitAllMetricUpdates = config.getBoolean(COMMIT_ALL_METRIC_UPDATES, false);
+    this.deferToExecutor = config.getBoolean(DEFER_TO_EXECUTOR_CONFIG, false);
+    metricUpdateIntervalSec = config.getLong(METRIC_UPDATE_INTERVAL_SEC_CONFIG, 1L);
     this.metricsRegistry.metrics().put(BEAM_METRICS_GROUP, new ConcurrentHashMap<>());
-    LOG.info("Creating Samza metrics container with userShortMetricName = {}", useShortMetricNames);
+
+    LOG.info(
+        "Creating Samza metrics container with deferToExecutor={}, metricUpdateIntervalSec={}, useShortMetricNames={}, commitAllMetricUpdates={}",
+        deferToExecutor,
+        metricUpdateIntervalSec,
+        useShortMetricNames,
+        commitAllMetricUpdates);
+    // Register a shutdown hook to gracefully shutdown the executor service
+    Runtime.getRuntime().addShutdownHook(new Thread(this::shutdownExecutorService));
   }
 
   public MetricsContainer getContainer(String stepName) {
@@ -81,15 +106,133 @@ public class SamzaMetricsContainer {
     return this.metricsContainers;
   }
 
-  /** Update Beam metrics to Samza metrics for the current step and global step. */
+  /**
+   * This is the public method for updating metrics. It either defers the update to the executor
+   * service or updates the metrics immediately based on the deferToExecutor configuration flag.
+   *
+   * @param stepName the step name for which metrics are being updated
+   */
   public void updateMetrics(String stepName) {
+    if (deferToExecutor) {
+      // Start executor service if it hasn't been started yet
+      startExecutorServiceIfNeeded();
 
-    assert metricsRegistry != null;
-    final List<String> stepNameList = Arrays.asList(stepName, GLOBAL_CONTAINER_STEP_NAME);
-    // Since global metrics do not belong to any step, we need to update it in every step.
-    final MetricResults metricResults =
+      // If using the executor, just schedule the step name for updates.
+      if (activeStepNames.add(stepName)) {
+        LOG.info("Added step '{}' for deferred metrics update.", stepName);
+      }
+    } else {
+      // If not deferring to the executor, update metrics immediately.
+      updateMetricsInternal(stepName);
+    }
+  }
+
+  /**
+   * Starts the executor service if it hasn't already been started, using a double-checked locking
+   * pattern.
+   *
+   * <p>The double-checked locking pattern optimizes the synchronization process: 1. First, the
+   * `executorServiceStarted` variable is checked outside the synchronized block. This avoids
+   * entering a synchronized block unnecessarily if the service has already been started. 2. If the
+   * service hasn't been started, synchronization is used to ensure that only one thread can start
+   * the executor service. The variable is checked again inside the synchronized block to avoid race
+   * conditions in a multi-threaded environment.
+   *
+   * <p>**Visibility Guarantees**: The `synchronized` block ensures that changes to
+   * `executorServiceStarted` made by one thread are visible to all other threads. This happens
+   * because the `synchronized` keyword guarantees a "happens-before" relationship, ensuring that
+   * updates to shared variables are safely published and visible to other threads.
+   *
+   * <p>This method ensures that the executor service, which periodically commits metrics updates,
+   * is initialized only once, minimizing resource usage.
+   */
+  private void startExecutorServiceIfNeeded() {
+    if (!executorServiceStarted) { // First check (outside synchronized block)
+      synchronized (this) {
+        if (!executorServiceStarted) { // Second check (inside synchronized block)
+          final ScheduledExecutorService scheduler =
+              Executors.newSingleThreadScheduledExecutor(
+                  new ThreadFactoryBuilder()
+                      .setDaemon(true)
+                      .setNameFormat("MetricsUpdater-thread")
+                      .build());
+          scheduledFuture =
+              scheduler.scheduleAtFixedRate(
+                  () -> {
+                    try {
+                      commitMetricsForAllSteps();
+                    } catch (Exception e) {
+                      LOG.error("Error occurred during periodic metrics update", e);
+                    }
+                  },
+                  0,
+                  metricUpdateIntervalSec,
+                  TimeUnit.SECONDS);
+          executorServiceStarted = true;
+          LOG.info("Started executor service for periodic metrics updates.");
+        }
+      }
+    }
+  }
+
+  /**
+   * Shutdown the executor service and cancel the scheduled task. Before shutting down, update
+   * metrics one last time to ensure completeness.
+   */
+  private void shutdownExecutorService() {
+    if (executorService != null && !executorService.isShutdown()) {
+      LOG.info("Shutting down executor service...");
+
+      // Cancel the scheduled task if it's still running.
+      // This ensures that any periodic metrics updates are stopped and no further updates
+      // are scheduled once we begin the shutdown process.
+      if (scheduledFuture != null && !scheduledFuture.isCancelled()) {
+        LOG.info("Cancelling scheduled metrics updates...");
+        scheduledFuture.cancel(true);
+      }
+
+      // Update metrics one last time, ensuring that we're still committing from a single thread.
+      // This guarantees that all remaining metrics are committed before shutting down the executor
+      // service.
+      commitMetricsForAllSteps();
+
+      // Shutdown the executor service gracefully.
+      // Allow any currently executing tasks to finish, then terminate the service. If the shutdown
+      // process takes longer than 5 seconds, force a shutdown to ensure the service is stopped.
+      executorService.shutdown();
+      try {
+        if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+          LOG.warn("Forcing shutdown of executor service...");
+          executorService.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        LOG.error("Interrupted during shutdown, forcing shutdown now", e);
+        executorService.shutdownNow();
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /**
+   * This method commits metrics updates for all scheduled steps. It is invoked periodically by the
+   * scheduled executor service when `deferToExecutor` is set to true and also during shutdown to
+   * ensure that any remaining metrics are committed before terminating the executor.
+   */
+  private void commitMetricsForAllSteps() {
+    activeStepNames.forEach(this::updateMetricsInternal);
+  }
+
+  /**
+   * Private method containing the core logic for updating metrics. This is either called
+   * immediately or by the executor service, depending on the configuration.
+   *
+   * @param stepName the step name for which metrics are being updated
+   */
+  private void updateMetricsInternal(String stepName) {
+    List<String> stepNameList = Arrays.asList(stepName, GLOBAL_CONTAINER_STEP_NAME);
+    MetricResults metricResults =
         asAttemptedOnlyMetricResultsForSteps(metricsContainers, stepNameList);
-    final MetricQueryResults results = metricResults.allMetrics();
+    MetricQueryResults results = metricResults.allMetrics();
 
     final CounterUpdater updateCounter = new CounterUpdater();
     results.getCounters().forEach(updateCounter);
@@ -99,6 +242,7 @@ public class SamzaMetricsContainer {
 
     final DistributionUpdater updateDistribution = new DistributionUpdater();
     results.getDistributions().forEach(updateDistribution);
+
     if (commitAllMetricUpdates) {
       stepNameList.stream()
           .map(metricsContainers::getContainer)


### PR DESCRIPTION
### PR Description:
This PR introduces a mechanism to offload the metrics update process from the main thread to background threads using a scheduled executor service. Key changes include:

- **Deferred Metrics Update**:
  Metrics updates are now committed periodically using a scheduled executor service. By reducing updates to once per second (rather than per message), we significantly lower the overhead on the main thread. The metrics backend (inGraphs) has a 1-minute granularity, so updating more frequently would not improve display accuracy.

- **Configurable Executor Service**:
  The update behavior is controlled by a configuration flag (`beam.samza.metrics.deferToExecutor`) and the interval is configurable, defaulting to 1 second.

- **Synchronization Improvements**:
  Proper synchronization ensures that concurrent updates from multiple threads do not lead to inconsistencies in the metrics container.

### Performance Gains:
By offloading metrics updates to background threads and batching them, we reduce the CPU consumption and avoid the overhead of frequent updates on the main thread. Since committing metrics and updating them is idempotent, updating at a lower frequency (e.g., once per second) won’t affect the display in inGraphs.

### Expected Outcome:
This change is expected to reduce the load on the main thread, eliminating performance bottlenecks and improving throughput, especially in high-throughput environments like the CTC repartitioner.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
