### PR TITLE
add engine agnostic GroupWithoutRepartition transform

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.30'
+    project.version = '2.45.31'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.30
-sdk_version=2.45.30
+version=2.45.31
+sdk_version=2.45.31
 
 javaVersion=1.8
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -1003,14 +1003,8 @@ class FlinkStreamingTransformTranslators {
               inputKvCoder.getKeyCoder(),
               new SerializablePipelineOptions(context.getPipelineOptions()));
 
-      KeyedStream<WindowedValue<KeyedWorkItem<K, byte[]>>, ByteBuffer> keyedWorkItemStream;
-
-      if (context.getCurrentTransform().getFullName().startsWith("GroupWithoutRepartition")) {
-        // skip reshuffle if the pipeline is explicitly using GroupWithoutRepartition
-        keyedWorkItemStream = DataStreamUtils.reinterpretAsKeyedStream(workItemStream, keySelector);
-      } else {
-        keyedWorkItemStream = workItemStream.keyBy(keySelector);
-      }
+      KeyedStream<WindowedValue<KeyedWorkItem<K, byte[]>>, ByteBuffer> keyedWorkItemStream =
+          workItemStream.keyBy(keySelector);
 
       SystemReduceFn<K, byte[], Iterable<byte[]>, Iterable<byte[]>, BoundedWindow> reduceFn =
           SystemReduceFn.buffering(ByteArrayCoder.of());

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -1003,8 +1003,14 @@ class FlinkStreamingTransformTranslators {
               inputKvCoder.getKeyCoder(),
               new SerializablePipelineOptions(context.getPipelineOptions()));
 
-      KeyedStream<WindowedValue<KeyedWorkItem<K, byte[]>>, ByteBuffer> keyedWorkItemStream =
-          workItemStream.keyBy(keySelector);
+      KeyedStream<WindowedValue<KeyedWorkItem<K, byte[]>>, ByteBuffer> keyedWorkItemStream;
+
+      if (context.getCurrentTransform().getFullName().startsWith("GroupWithoutRepartition")) {
+        // skip reshuffle if the pipeline is explicitly using GroupWithoutRepartition
+        keyedWorkItemStream = DataStreamUtils.reinterpretAsKeyedStream(workItemStream, keySelector);
+      } else {
+        keyedWorkItemStream = workItemStream.keyBy(keySelector);
+      }
 
       SystemReduceFn<K, byte[], Iterable<byte[]>, Iterable<byte[]>, BoundedWindow> reduceFn =
           SystemReduceFn.buffering(ByteArrayCoder.of());

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/GroupByKeyTranslator.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/GroupByKeyTranslator.java
@@ -262,7 +262,8 @@ class GroupByKeyTranslator<K, InputT, OutputT>
       return true;
     }
 
-    if (node.getTransform() instanceof GroupWithoutRepartition) {
+    if (node.getTransform() instanceof GroupWithoutRepartition
+        || node.getTransform() instanceof org.apache.beam.sdk.transforms.GroupWithoutRepartition) {
       return false;
     } else {
       return needRepartition(node.getEnclosingNode(), ctx);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/GroupWithoutRepartition.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/GroupWithoutRepartition.java
@@ -15,9 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.runners.samza.transforms;
+package org.apache.beam.sdk.transforms;
 
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.join.KeyedPCollectionTuple;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PInput;
@@ -26,19 +25,16 @@ import org.apache.beam.sdk.values.POutput;
 /**
  * A wrapper transform of {@link org.apache.beam.sdk.transforms.GroupByKey} or {@link
  * org.apache.beam.sdk.transforms.join.CoGroupByKey} to indicate there is no repartition needed for
- * Samza runner. For example:
+ * Flink runner. For example:
  *
  * <p>input.apply(GroupWithoutRepartition.of(Count.perKey()));
- *
- * @deprecated use {@link org.apache.beam.sdk.transforms.GroupWithoutRepartition} instead.
  */
-@Deprecated
 public class GroupWithoutRepartition<InputT extends PInput, OutputT extends POutput>
     extends PTransform<InputT, OutputT> {
   private final PTransform<InputT, OutputT> transform;
 
   public static <InputT extends PInput, OutputT extends POutput>
-      GroupWithoutRepartition<InputT, OutputT> of(PTransform<InputT, OutputT> transform) {
+  GroupWithoutRepartition<InputT, OutputT> of(PTransform<InputT, OutputT> transform) {
     return new GroupWithoutRepartition<>(transform);
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/GroupWithoutRepartition.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/GroupWithoutRepartition.java
@@ -28,7 +28,11 @@ import org.apache.beam.sdk.values.POutput;
  * Flink runner. For example:
  *
  * <p>input.apply(GroupWithoutRepartition.of(Count.perKey()));
+ *
+ * @deprecated this transform's sole purposes is to maintain backward compatibility
+ * for existing LinkedIn internal use cases. Do not use this class for new development.
  */
+@Deprecated
 public class GroupWithoutRepartition<InputT extends PInput, OutputT extends POutput>
     extends PTransform<InputT, OutputT> {
   private final PTransform<InputT, OutputT> transform;


### PR DESCRIPTION
This PR deprecates the samza runner specific `GroupWithoutRepartition` and adds the engine agnostic version of it.

Please note that the engine agnostic implemented is purely for the purpose of maintaining backward compatibility for existing LinkedIn internal use cases. Do not use for any new development.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
