### PR TITLE
fix reshuffle translation

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.34'
+    project.version = '2.45.35'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.34
-sdk_version=2.45.34
+version=2.45.35
+sdk_version=2.45.35
 
 javaVersion=1.8
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -110,6 +110,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterable
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
@@ -954,7 +955,11 @@ class FlinkStreamingTransformTranslators {
       DataStream<WindowedValue<KV<K, InputT>>> inputDataSet =
           context.getInputDataStream(context.getInput(transform));
 
-      context.setOutputDataStream(context.getOutput(transform), inputDataSet.rebalance());
+      DataStream<WindowedValue<KV<K, InputT>>> outputDataset =
+          inputDataSet.partitionCustom((Partitioner<K>) (key, numPartitions) ->
+              Math.abs(key.hashCode()) % numPartitions, input -> input.getValue().getKey());
+
+      context.setOutputDataStream(context.getOutput(transform), outputDataset);
     }
   }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -957,7 +957,8 @@ class FlinkStreamingTransformTranslators {
 
       DataStream<WindowedValue<KV<K, InputT>>> outputDataset =
           inputDataSet.partitionCustom(
-              (Partitioner<K>) (key, numPartitions) -> Math.abs(key.hashCode()) % numPartitions,
+              (Partitioner<K>)
+                  (key, numPartitions) -> (key.hashCode() & Integer.MAX_VALUE) % numPartitions,
               input -> input.getValue().getKey());
 
       context.setOutputDataStream(context.getOutput(transform), outputDataset);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -956,8 +956,9 @@ class FlinkStreamingTransformTranslators {
           context.getInputDataStream(context.getInput(transform));
 
       DataStream<WindowedValue<KV<K, InputT>>> outputDataset =
-          inputDataSet.partitionCustom((Partitioner<K>) (key, numPartitions) ->
-              Math.abs(key.hashCode()) % numPartitions, input -> input.getValue().getKey());
+          inputDataSet.partitionCustom(
+              (Partitioner<K>) (key, numPartitions) -> Math.abs(key.hashCode()) % numPartitions,
+              input -> input.getValue().getKey());
 
       context.setOutputDataStream(context.getOutput(transform), outputDataset);
     }


### PR DESCRIPTION
## Background

According to the [Java doc](https://github.com/apache/beam/blob/master/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Reshuffle.java#L51) of Beam reshuffle, it should perform the following operation:

```
Performs a {@link GroupByKey} so that the data is key-partitioned. Configures the {@link WindowingStrategy} so that no data is dropped, but doesn't affect the need for the user to specify allowed lateness and accumulation mode before a user-inserted GroupByKey.
```

However, the current Flink translation of `Reshuffle` simply performs a DataStream `rebalance`, which is not the same as a key partition. 

## Fix

This PR updates the `Reshuffle` translation to perform a **physical** repartition based on the `Hash Code` of the key (assign record to partition `hashcode % numPartitions`).

A few things to note:

- We are using the [partitionCustom](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/operators/overview/#physical-partitioning) operator instead of [keyBy](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/operators/overview/#keyby) for 2 reasons:
    1. The downstream of a `Reshuffle` expects a `DataStream` instead of a `KeyedStream`.
    2. `keyBy` is a logical partitioning, for reshuffle we need to physically repartition the data.
- The current partitioning logic that determines which partition to write the event to is `destPartition = hashcodeOfEvent % numPartitions`, which could cause data skew depending on the hashing mechanism of the key. We might want to revisit the `Partitioner` implementation if this becomes a significant bottleneck.

## Testing
```
./gradlew :runners:flink:1.18:validatesRunner
```
passes

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
