### PR TITLE
Add Timer Batch Limit in DoFnOp

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.34'
+    project.version = '2.45.35'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.34
-sdk_version=2.45.34
+version=2.45.35
+sdk_version=2.45.35
 
 javaVersion=1.8
 

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/DoFnOp.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/DoFnOp.java
@@ -186,7 +186,7 @@ public class DoFnOp<InT, FnOutT, OutT> implements Op<InT, OutT, Void> {
       Context context,
       Scheduler<KeyedTimerData<Void>> timerRegistry,
       OpEmitter<OutT> emitter) {
-    this.timerBatchLimit = config.getInt(TIMER_BATCH_LIMIT_CONFIG,Integer.MAX_VALUE);
+    this.timerBatchLimit = config.getInt(TIMER_BATCH_LIMIT_CONFIG, Integer.MAX_VALUE);
     this.inputWatermark = BoundedWindow.TIMESTAMP_MIN_VALUE;
     this.sideInputWatermark = BoundedWindow.TIMESTAMP_MIN_VALUE;
     this.pushbackWatermarkHold = BoundedWindow.TIMESTAMP_MAX_VALUE;

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/DoFnOp.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/DoFnOp.java
@@ -76,8 +76,7 @@ import org.slf4j.LoggerFactory;
 })
 public class DoFnOp<InT, FnOutT, OutT> implements Op<InT, OutT, Void> {
   private static final Logger LOG = LoggerFactory.getLogger(DoFnOp.class);
-  public static final String TIMER_BATCH_LIMIT_CONFIG =
-      "beam.samza.dofnop.timerBatchLimit";
+  public static final String TIMER_BATCH_LIMIT_CONFIG = "beam.samza.dofnop.timerBatchLimit";
 
   private final TupleTag<FnOutT> mainOutputTag;
   private final DoFn<InT, FnOutT> doFn;


### PR DESCRIPTION
## Description
This PR introduces a configurable timer batch limit (`TIMER_BATCH_LIMIT`) in `DoFnOp` to address memory issues observed in high-scale scenarios where multiple timers fire simultaneously. In the current implementation, all ready timers are fired in a single loop without batching, leading to excessive memory usage and out-of-memory (OOM) errors. The key changes in this PR are:

1. **Batch Timer Processing**:
   - Added a configurable `TIMER_BATCH_LIMIT` parameter (`beam.samza.dofnop.timerBatchLimit`).
   - Updated the `doProcessWatermark` method to process timers in chunks, limiting the number of timers fired in a single loop to reduce memory spikes.
   - This ensures incremental processing of timers, reducing memory usage and improving system stability.

2. **Implementation Details**:
   - A default limit of `Integer.MAX_VALUE` is used if no configuration is provided, maintaining current behavior for backward compatibility.
   - Timer processing is divided into batches, where each batch processes up to `TIMER_BATCH_LIMIT` timers. After each batch, outputs are emitted and memory is cleared.

3. **Code Changes**:
   - Introduced `TIMER_BATCH_LIMIT_CONFIG` for configurable timer batch limits.
   - Modified `doProcessWatermark` to iterate over timers in chunks, respecting the batch limit.

---

### Addresses
This PR addresses memory issues caused by the unbounded accumulation of timer outputs during high-scale workloads in `DoFnOp`.

### Testing
- build