### PR TITLE
remove flinkConfMap from FlinkPipelineOptions

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.37'
+    project.version = '2.45.38'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.37
-sdk_version=2.45.37
+version=2.45.38
+sdk_version=2.45.38
 
 javaVersion=1.8
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -382,7 +382,8 @@ public class FlinkExecutionEnvironments {
   static Configuration getFlinkConfiguration(
       @Nullable String flinkConfDir, FlinkPipelineOptions flinkPipelineOptions) {
     Configuration dynamicProperties = null;
-    final Map<String, String> flinkConfMap = ExternalConfigRegistrar.getConfig(flinkPipelineOptions);
+    final Map<String, String> flinkConfMap =
+        ExternalConfigRegistrar.getConfig(flinkPipelineOptions);
     if (!flinkConfMap.isEmpty()) {
       dynamicProperties = Configuration.fromMap(flinkConfMap);
     }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -382,8 +382,7 @@ public class FlinkExecutionEnvironments {
   static Configuration getFlinkConfiguration(
       @Nullable String flinkConfDir, FlinkPipelineOptions flinkPipelineOptions) {
     Configuration dynamicProperties = null;
-    final Map<String, String> flinkConfMap = flinkPipelineOptions.getFlinkConfMap();
-    flinkConfMap.putAll(ExternalConfigRegistrar.getConfig(flinkPipelineOptions));
+    final Map<String, String> flinkConfMap = ExternalConfigRegistrar.getConfig(flinkPipelineOptions);
     if (!flinkConfMap.isEmpty()) {
       dynamicProperties = Configuration.fromMap(flinkConfMap);
     }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -308,20 +308,6 @@ public interface FlinkPipelineOptions
 
   void setFlinkConfDir(String confDir);
 
-  @Description("Map containing Flink configurations")
-  @Default.InstanceFactory(FlinkConfMapFactory.class)
-  Map<String, String> getFlinkConfMap();
-
-  void setFlinkConfMap(Map<String, String> flinkConfMap);
-
-  /** Returns an empty map, to avoid handling null. */
-  class FlinkConfMapFactory implements DefaultValueFactory<Map<String, String>> {
-    @Override
-    public Map<String, String> create(PipelineOptions options) {
-      return new HashMap<>();
-    }
-  }
-
   static FlinkPipelineOptions defaults() {
     return PipelineOptionsFactory.as(FlinkPipelineOptions.class);
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -17,11 +17,8 @@
  */
 package org.apache.beam.runners.flink;
 
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.beam.sdk.options.ApplicationNameOptions;
 import org.apache.beam.sdk.options.Default;
-import org.apache.beam.sdk.options.DefaultValueFactory;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.FileStagingOptions;
 import org.apache.beam.sdk.options.PipelineOptions;

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkExecutionEnvironmentsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkExecutionEnvironmentsTest.java
@@ -504,16 +504,6 @@ public class FlinkExecutionEnvironmentsTest {
     assertNotNull(configuration);
   }
 
-  @Test
-  public void testGetFlinkConfigurationWithConfigMap() {
-    FlinkPipelineOptions options = getDefaultPipelineOptions();
-    options.setFlinkConfMap(
-        new HashMap<>(ImmutableMap.<String, String>builder().put("mapKey", "mapValue").build()));
-    Configuration configuration = getFlinkConfiguration(null, options);
-    assertTrue(configuration.containsKey("mapKey"));
-    assertEquals("mapValue", configuration.getString("mapKey", ""));
-  }
-
   private void checkHostAndPort(Object env, String expectedHost, int expectedPort) {
     String host =
         ((Configuration) Whitebox.getInternalState(env, "configuration"))

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkExecutionEnvironmentsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkExecutionEnvironmentsTest.java
@@ -24,7 +24,6 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,8 +33,6 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.LocalEnvironment;
 import org.apache.flink.api.java.RemoteEnvironment;


### PR DESCRIPTION
In https://github.com/linkedin/beam/pull/129 we added `FlinkConfMap` to `FlinkPipelineOptions` so that we can all Li users to easier configure Flink native configs in local testing. 
Later in https://github.com/linkedin/beam/pull/140 we added `ExternalConfigRegistrar` to allow external configs to be injected to both Samza Runner and Flink Runner.
With `ExternalConfigRegistrar` being able to allow Li users configure Flink native configs for Flink, the `FlinkConfMap` becomes redundant. This change removes `FlinkConfMap` in `FlinkPipelineOptions` to avoid abuse of it.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
