### PR TITLE
Fix Race Condition in removeReadyTimers() to Prevent Cleared Timers from Firing

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.38'
+    project.version = '2.45.39'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.38
-sdk_version=2.45.38
+version=2.45.39
+sdk_version=2.45.39
 
 javaVersion=1.8
 

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/DoFnOp.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/DoFnOp.java
@@ -329,14 +329,9 @@ public class DoFnOp<InT, FnOutT, OutT> implements Op<InT, OutT, Void> {
 
     timerInternalsFactory.setInputWatermark(actualInputWatermark);
 
-    Collection<? extends KeyedTimerData<?>> readyTimers = timerInternalsFactory.removeReadyTimers();
-    if (!readyTimers.isEmpty()) {
-      pushbackFnRunner.startBundle();
-      for (KeyedTimerData<?> keyedTimerData : readyTimers) {
-        fireTimer(keyedTimerData);
-      }
-      pushbackFnRunner.finishBundle();
-    }
+    pushbackFnRunner.startBundle();
+    timerInternalsFactory.fireReadyTimers(this::fireTimer);
+    pushbackFnRunner.finishBundle();
 
     if (timerInternalsFactory.getOutputWatermark() == null
         || timerInternalsFactory.getOutputWatermark().isBefore(actualInputWatermark)) {

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/GroupByKeyOp.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/GroupByKeyOp.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.runners.samza.runtime;
 
-import java.util.Collection;
 import java.util.Collections;
 import org.apache.beam.runners.core.DoFnRunner;
 import org.apache.beam.runners.core.DoFnRunners;
@@ -207,14 +206,9 @@ public class GroupByKeyOp<K, InputT, OutputT>
   public void processWatermark(Instant watermark, OpEmitter<KV<K, OutputT>> emitter) {
     timerInternalsFactory.setInputWatermark(watermark);
 
-    Collection<KeyedTimerData<K>> readyTimers = timerInternalsFactory.removeReadyTimers();
-    if (!readyTimers.isEmpty()) {
-      fnRunner.startBundle();
-      for (KeyedTimerData<K> keyedTimerData : readyTimers) {
-        fireTimer(keyedTimerData.getKey(), keyedTimerData.getTimerData());
-      }
-      fnRunner.finishBundle();
-    }
+    fnRunner.startBundle();
+    timerInternalsFactory.fireReadyTimers(timer -> fireTimer(timer.getKey(), timer.getTimerData()));
+    fnRunner.finishBundle();
 
     if (timerInternalsFactory.getOutputWatermark() == null
         || timerInternalsFactory.getOutputWatermark().isBefore(watermark)) {

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaTimerInternalsFactory.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaTimerInternalsFactory.java
@@ -259,7 +259,7 @@ public class SamzaTimerInternalsFactory<K> implements TimerInternalsFactory<K> {
         break;
       }
     }
-
+    LOG.debug("Processed {} expired timers at this watermark.", processedCount);
     // Log a warning if we've hit the processing limit and there are still expired timers remaining.
     if (processedCount == maxReadyTimersToProcessOnce
         && !eventTimeBuffer.isEmpty()

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaTimerInternalsFactory.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaTimerInternalsFactory.java
@@ -207,6 +207,69 @@ public class SamzaTimerInternalsFactory<K> implements TimerInternalsFactory<K> {
     state.deletePersisted(keyedTimerData);
   }
 
+  /** Functional interface for firing a timer. */
+  @FunctionalInterface
+  public interface TimeFiringFn<K> {
+    void fire(KeyedTimerData<K> timerData);
+  }
+
+  /**
+   * Processes and fires ready timers, ensuring that at most {@code maxReadyTimersToProcessOnce}
+   * timers are handled per invocation.
+   *
+   * <p>Steps:
+   *
+   * <ol>
+   *   <li>If the event time buffer is empty, reload timers from state.
+   *   <li>Process timers up to the max limit:
+   *       <ul>
+   *         <li>Check if the next timer is due (timestamp ≤ input watermark).
+   *         <li>If valid, remove it from the buffer, verify its state, and fire it.
+   *       </ul>
+   *   <li>If the max limit is reached and expired timers remain, log a warning.
+   * </ol>
+   *
+   * @param firingFn function to fire each valid timer
+   */
+  public void fireReadyTimers(TimeFiringFn<K> firingFn) {
+    int processedCount = 0;
+
+    while (processedCount < maxReadyTimersToProcessOnce) {
+      // If the buffer is empty, attempt to reload timers from state.
+      if (eventTimeBuffer.isEmpty()) {
+        state.reloadEventTimeTimers();
+        // If still empty after reloading, break out as there are no timers to process.
+        if (eventTimeBuffer.isEmpty()) {
+          break;
+        }
+      }
+
+      // Process the timer only if it is due (timestamp <= inputWatermark).
+      if (!eventTimeBuffer.first().getTimerData().getTimestamp().isAfter(inputWatermark)) {
+        final KeyedTimerData<K> timer = eventTimeBuffer.pollFirst();
+        final Long storedTimestamp = state.get(timer);
+        if (storedTimestamp != null
+            && storedTimestamp.equals(timer.getTimerData().getTimestamp().getMillis())) {
+          state.deletePersisted(timer);
+          firingFn.fire(timer);
+          processedCount++;
+        }
+      } else {
+        // No more timers are due.
+        break;
+      }
+    }
+
+    // Log a warning if we've hit the processing limit and there are still expired timers remaining.
+    if (processedCount == maxReadyTimersToProcessOnce
+        && !eventTimeBuffer.isEmpty()
+        && eventTimeBuffer.first().getTimerData().getTimestamp().isBefore(inputWatermark)) {
+      LOG.warn(
+          "Loaded {} expired timers, the remaining will be processed at next watermark.",
+          maxReadyTimersToProcessOnce);
+    }
+  }
+
   public Instant getInputWatermark() {
     return inputWatermark;
   }

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SplittableParDoProcessKeyedElementsOp.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SplittableParDoProcessKeyedElementsOp.java
@@ -221,14 +221,9 @@ public class SplittableParDoProcessKeyedElementsOp<
   public void processWatermark(Instant watermark, OpEmitter<RawUnionValue> emitter) {
     timerInternalsFactory.setInputWatermark(watermark);
 
-    Collection<KeyedTimerData<byte[]>> readyTimers = timerInternalsFactory.removeReadyTimers();
-    if (!readyTimers.isEmpty()) {
-      fnRunner.startBundle();
-      for (KeyedTimerData<byte[]> keyedTimerData : readyTimers) {
-        fireTimer(keyedTimerData.getKey(), keyedTimerData.getTimerData());
-      }
-      fnRunner.finishBundle();
-    }
+    fnRunner.startBundle();
+    timerInternalsFactory.fireReadyTimers(timer -> fireTimer(timer.getKey(), timer.getTimerData()));
+    fnRunner.finishBundle();
 
     if (timerInternalsFactory.getOutputWatermark() == null
         || timerInternalsFactory.getOutputWatermark().isBefore(watermark)) {

--- a/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/SamzaTimerInternalsFactoryTest.java
+++ b/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/SamzaTimerInternalsFactoryTest.java
@@ -687,4 +687,50 @@ public class SamzaTimerInternalsFactoryTest {
     assertTrue(!map.containsKey(key2));
     assertTrue(map.isEmpty());
   }
+
+  @Test
+  public void testFireReadyTimersConsolidatedLogic() {
+    // Set up the pipeline options and state store.
+    SamzaPipelineOptions pipelineOptions =
+        PipelineOptionsFactory.create().as(SamzaPipelineOptions.class);
+    KeyValueStore<ByteArray, StateValue<?>> store = createStore();
+    final SamzaTimerInternalsFactory<String> timerInternalsFactory =
+        createTimerInternalsFactory(null, "timer", pipelineOptions, store);
+
+    final String key = "testKey";
+    final StateNamespace namespace = StateNamespaces.global();
+    // Get the TimerInternals for the key.
+    TimerInternals timerInternals = timerInternalsFactory.timerInternalsForKey(key);
+
+    // Create two timers with different timestamps.
+    TimerInternals.TimerData timer1 =
+        TimerInternals.TimerData.of(
+            "timer1", namespace, new Instant(10), new Instant(10), TimeDomain.EVENT_TIME);
+    TimerInternals.TimerData timer2 =
+        TimerInternals.TimerData.of(
+            "timer2", namespace, new Instant(20), new Instant(20), TimeDomain.EVENT_TIME);
+    // Set the timers.
+    timerInternals.setTimer(timer1);
+    timerInternals.setTimer(timer2);
+
+    // Set the input watermark such that both timers are due.
+    timerInternalsFactory.setInputWatermark(new Instant(30));
+
+    // List to collect fired timers.
+    final List<KeyedTimerData<String>> firedTimers = new ArrayList<>();
+
+    // Invoke the consolidated timer firing logic.
+    timerInternalsFactory.fireReadyTimers(timer -> firedTimers.add(timer));
+
+    // Verify that both timers have been fired in order.
+    assertEquals("Expected two fired timers", 2, firedTimers.size());
+    assertEquals("First fired timer should be timer1", timer1, firedTimers.get(0).getTimerData());
+    assertEquals("Second fired timer should be timer2", timer2, firedTimers.get(1).getTimerData());
+
+    // Also, the event time buffer should be empty after firing.
+    assertTrue(
+        "Event time buffer should be empty", timerInternalsFactory.getEventTimeBuffer().isEmpty());
+
+    store.close();
+  }
 }


### PR DESCRIPTION
## Issue Summary

A race condition in `removeReadyTimers()` allows timers that were cleared in the same batch to still fire. This occurs because the method loads timers into `eventTimeBuffer` in batches, and if an earlier timer clears a later timer, the later timer is still added to `readyTimers`. However, since `state.get(timerKey, timeDomain)` returns `null` (or `0`) after deletion, it fails to be properly removed, leading to it firing incorrectly when it should have been cleared.

## Root Cause

1. `removeReadyTimers()` removes timers from `eventTimeBuffer` and adds them to `readyTimers`.
2. Timers are deleted from persistent state using `state.deletePersisted(keyedTimerData)`.
3. If an earlier timer in the same batch clears a later timer, the later timer is already removed from state, making `state.get(timerKey, timeDomain)` return `null`.
4. This causes the later timer to still exist in `readyTimers`, leading to it firing when it should have been cleared.

## Proposed Solution

To address this race condition, we have **consolidated the removal and firing logic into a single method, `fireReadyTimers()`**, ensuring that timers are verified in persistent state before being fired. The updated approach works as follows:

- **Deferred Deletion Until Firing:** Timers are first collected from the `eventTimeBuffer` without immediately deleting them from persistent state.
- **State Verification Before Firing:** Each timer is checked against `state.get(timerKey, timeDomain)`. If it still exists in persistent state **and its stored timestamp matches**, it is deleted and fired.
- **Consolidation of Logic:** The previous `removeReadyTimers()` function was eliminated, and all related calls (e.g., in `DoFnOp`, `GroupByKeyOp`, and `SplittableParDoProcessKeyedElementsOp`) were updated to use `fireReadyTimers()`.
- **Batch Processing Remains Consistent:** If a timer was adjusted (i.e., rescheduled), the stored timestamp will no longer match, and the timer will not be fired immediately. Instead, it will be processed in the next batch when its new timestamp becomes due.
- **Automatic Timer Buffer Reloading:** When the in-memory timer buffer is emptied, timers are reloaded from persistent state to ensure that no due timers are missed.

### Code Changes:
- **Introduced `fireReadyTimers()`** in `SamzaTimerInternalsFactory`, replacing `removeReadyTimers()`.
- **Updated `DoFnOp`, `GroupByKeyOp`, and `SplittableParDoProcessKeyedElementsOp`** to invoke `fireReadyTimers()` instead of handling timers separately.
- **Added a unit test in `SamzaTimerInternalsFactoryTest`** to verify that `fireReadyTimers()` correctly processes and fires timers while ensuring that cleared timers are not fired.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
