### PR TITLE
fix BoundValue cast issue

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.40'
+    project.version = '2.45.41'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.40
-sdk_version=2.45.40
+version=2.45.41
+sdk_version=2.45.41
 
 javaVersion=1.8
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -219,12 +219,13 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
         final PropertyCustomizationHandler handler = PropertyCustomizationHandler.get();
         if (handler != null && handler.isCustomizationEnabled() && handler.containsProperty(method, propertyName)) {
           value = handler.getProperty(method, propertyName);
+          options.put(propertyName, (BoundValue) value);
         } else {
           // Lazy bind the default to the method.
           value = jsonOptions.containsKey(propertyName) ? getValueFromJson(propertyName, method)
               : getDefault((PipelineOptions) proxy, method);
+          options.put(propertyName, BoundValue.fromDefault(value));
         }
-        options.put(propertyName, BoundValue.fromDefault(value));
       }
       return options.get(propertyName).getValue();
     } else if (properties.settersToPropertyNames.containsKey(methodName)) {


### PR DESCRIPTION
Fix issues
```
java.lang.ClassCastException: class org.apache.beam.sdk.options.AutoValue_ProxyInvocationHandler_BoundValue cannot be cast to class java.lang.Long (org.apache.beam.sdk.options.AutoValue_ProxyInvocationHandler_BoundValue is in unnamed module of loader 'app'; java.lang.Long is in module java.base of loader 'bootstrap')
                    at com.sun.proxy.$Proxy41.getShutdownSourcesAfterIdleMs(Unknown Source)
                  
```

The value type in handler is already BoundValue, no need to convert, we can directly put it to options.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
