### PR TITLE
Avoid registering pushed-back states for stateless DoFnOperator

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.45'
+    project.version = '2.45.46'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.45
-sdk_version=2.45.45
+version=2.45.46
+sdk_version=2.45.46
 
 javaVersion=1.8
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -96,7 +96,6 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditio
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.flink.api.common.operators.ProcessingTimeService.ProcessingTimeCallback;
-import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.MapStateDescriptor;
@@ -425,8 +424,9 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
           KeyedPushedBackElementsHandler.create(
               keySelector, getKeyedStateBackend(), pushedBackStateDescriptor);
     } else {
-      pushedBackElementsHandler = NonKeyedPushedBackElementsHandler.create(
-          getOperatorStateBackend(), pushedBackStateDescriptor);
+      pushedBackElementsHandler =
+          NonKeyedPushedBackElementsHandler.create(
+              getOperatorStateBackend(), pushedBackStateDescriptor);
     }
 
     currentInputWatermark = BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis();

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -425,9 +425,8 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
           KeyedPushedBackElementsHandler.create(
               keySelector, getKeyedStateBackend(), pushedBackStateDescriptor);
     } else {
-      ListState<WindowedValue<InputT>> listState =
-          getOperatorStateBackend().getListState(pushedBackStateDescriptor);
-      pushedBackElementsHandler = NonKeyedPushedBackElementsHandler.create(listState);
+      pushedBackElementsHandler = NonKeyedPushedBackElementsHandler.create(
+          getOperatorStateBackend(), pushedBackStateDescriptor);
     }
 
     currentInputWatermark = BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis();
@@ -1394,10 +1393,9 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
       ListStateDescriptor<KV<Integer, WindowedValue<?>>> taggedOutputPushbackStateDescriptor =
           new ListStateDescriptor<>(
               "bundle-buffer-tag", new CoderTypeSerializer<>(taggedKvCoder, pipelineOptions));
-      ListState<KV<Integer, WindowedValue<?>>> listStateBuffer =
-          operatorStateBackend.getListState(taggedOutputPushbackStateDescriptor);
       PushedBackElementsHandler<KV<Integer, WindowedValue<?>>> pushedBackElementsHandler =
-          NonKeyedPushedBackElementsHandler.create(listStateBuffer);
+          NonKeyedPushedBackElementsHandler.create(
+              operatorStateBackend, taggedOutputPushbackStateDescriptor);
 
       return new BufferedOutputManager<>(
           output, mainTag, tagsToOutputTags, tagsToIds, bufferLock, pushedBackElementsHandler);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
@@ -45,11 +45,11 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
     return new KeyedPushedBackElementsHandler<>(keySelector, backend, stateDescriptor);
   }
 
-  private final KeySelector<T, K> keySelector;
   private final KeyedStateBackend<K> backend;
-  private final String stateName;
+
+  private final KeySelector<T, K> keySelector;
   private final ListStateDescriptor<T> stateDescriptor;
-  @Nullable private ListState<T> state;
+  @Nullable private ListState<T> elementState;
 
   private KeyedPushedBackElementsHandler(
       KeySelector<T, K> keySelector,
@@ -58,71 +58,70 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
       throws Exception {
     this.keySelector = Objects.requireNonNull(keySelector);
     this.backend = Objects.requireNonNull(backend);
-    this.stateName = stateDescriptor.getName();
     this.stateDescriptor = Objects.requireNonNull(stateDescriptor);
-  }
-
-  @Override
-  public Stream<T> getElements() {
-    if (state != null) {
-      final ListState<T> s = state;
-      return backend
-          .getKeys(stateName, VoidNamespace.INSTANCE)
-          .flatMap(
-              key -> {
-                try {
-                  backend.setCurrentKey(key);
-                  return StreamSupport.stream(s.get().spliterator(), false);
-                } catch (Exception e) {
-                  throw new RuntimeException("Error reading keyed state.", e);
-                }
-              });
-    } else {
-      return Stream.empty();
+    // check if the state is restored from a checkpoint
+    if (this.backend.getKeys(stateDescriptor.getName(), VoidNamespace.INSTANCE).count() > 0) {
+      // Eagerly retrieve the state to work around https://jira.apache.org/jira/browse/FLINK-12653
+      this.elementState = backend.getPartitionedState(
+          VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
     }
   }
 
   @Override
+  public Stream<T> getElements() {
+    if (elementState == null) {
+      return Stream.empty();
+    }
+
+    final ListState<T> state = elementState;
+    return backend.getKeys(stateDescriptor.getName(), VoidNamespace.INSTANCE)
+        .flatMap(key -> {
+          try {
+            backend.setCurrentKey(key);
+            return StreamSupport.stream(state.get().spliterator(), false);
+          } catch (Exception e) {
+            throw new RuntimeException("Error reading keyed state.", e);
+          }
+        });
+  }
+
+  @Override
   public void clear() throws Exception {
-    if (state != null) {
-      final ListState<T> s = state;
+    if (elementState != null) {
+      final ListState<T> state = elementState;
       // TODO we have to collect all keys because otherwise we get ConcurrentModificationExceptions
       // from flink. We can change this once it's fixed in Flink
       List<K> keys =
-          backend.getKeys(stateName, VoidNamespace.INSTANCE).collect(Collectors.toList());
+          backend.getKeys(stateDescriptor.getName(), VoidNamespace.INSTANCE).collect(Collectors.toList());
 
       for (K key : keys) {
         backend.setCurrentKey(key);
-        s.clear();
+        state.clear();
       }
     }
   }
 
   @Override
   public void pushBack(T element) throws Exception {
-    if (state == null) {
-      // Eagerly retrieve the state to work around https://jira.apache.org/jira/browse/FLINK-12653
-      this.state =
-          backend.getPartitionedState(
-              VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
-    }
-    final ListState<T> s = state;
+    ListState<T> state = getOrCreateState();
     backend.setCurrentKey(keySelector.getKey(element));
-    s.add(element);
+    state.add(element);
   }
 
   @Override
   public void pushBackAll(Iterable<T> elements) throws Exception {
-    if (state == null) {
-      // Eagerly retrieve the state to work around https://jira.apache.org/jira/browse/FLINK-12653
-      this.state =
-          backend.getPartitionedState(
-              VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
-    }
-    final ListState<T> s = state;
+    ListState<T> state = getOrCreateState();
     for (T e : elements) {
       backend.setCurrentKey(keySelector.getKey(e));
-      s.add(e);
+      state.add(e);
     }
+  }
+
+  private ListState<T> getOrCreateState() throws Exception {
+    if (elementState == null) {
+      this.elementState = backend.getPartitionedState(
+          VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
+    }
+    return elementState;
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
@@ -64,32 +64,33 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
 
   @Override
   public Stream<T> getElements() {
-    if (state == null) return Stream.empty();
-    final ListState<T> s = state;
-    return backend
-        .getKeys(stateName, VoidNamespace.INSTANCE)
-        .flatMap(
-            key -> {
-              try {
-                backend.setCurrentKey(key);
-                return StreamSupport.stream(s.get().spliterator(), false);
-              } catch (Exception e) {
-                throw new RuntimeException("Error reading keyed state.", e);
-              }
-            });
+    if (state != null) {
+      final ListState<T> s = state;
+      return backend.getKeys(stateName, VoidNamespace.INSTANCE).flatMap(key -> {
+        try {
+          backend.setCurrentKey(key);
+          return StreamSupport.stream(s.get().spliterator(), false);
+        } catch (Exception e) {
+          throw new RuntimeException("Error reading keyed state.", e);
+        }
+      });
+    } else {
+      return Stream.empty();
+    }
   }
 
   @Override
   public void clear() throws Exception {
-    if (state == null) return;
-    final ListState<T> s = state;
-    // TODO we have to collect all keys because otherwise we get ConcurrentModificationExceptions
-    // from flink. We can change this once it's fixed in Flink
-    List<K> keys = backend.getKeys(stateName, VoidNamespace.INSTANCE).collect(Collectors.toList());
+    if (state != null) {
+      final ListState<T> s = state;
+      // TODO we have to collect all keys because otherwise we get ConcurrentModificationExceptions
+      // from flink. We can change this once it's fixed in Flink
+      List<K> keys = backend.getKeys(stateName, VoidNamespace.INSTANCE).collect(Collectors.toList());
 
-    for (K key : keys) {
-      backend.setCurrentKey(key);
-      s.clear();
+      for (K key : keys) {
+        backend.setCurrentKey(key);
+        s.clear();
+      }
     }
   }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
@@ -105,7 +105,7 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
     pushBack0(element);
   }
 
-  public void pushBack0(T element) throws Exception {
+  private void pushBack0(T element) throws Exception {
     backend.setCurrentKey(keySelector.getKey(element));
     state.add(element);
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
@@ -47,7 +47,8 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
   private final KeySelector<T, K> keySelector;
   private final KeyedStateBackend<K> backend;
   private final String stateName;
-  private final ListState<T> state;
+  private final ListStateDescriptor<T> stateDescriptor;
+  private ListState<T> state;
 
   private KeyedPushedBackElementsHandler(
       KeySelector<T, K> keySelector,
@@ -57,14 +58,21 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
     this.keySelector = Objects.requireNonNull(keySelector);
     this.backend = Objects.requireNonNull(backend);
     this.stateName = stateDescriptor.getName();
-    // Eagerly retrieve the state to work around https://jira.apache.org/jira/browse/FLINK-12653
-    this.state =
-        backend.getPartitionedState(
-            VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
+    this.stateDescriptor = Objects.requireNonNull(stateDescriptor);
+  }
+
+  private void ensureStateInitialized() throws Exception {
+    if (state == null) {
+      // Eagerly retrieve the state to work around https://jira.apache.org/jira/browse/FLINK-12653
+      this.state =
+          backend.getPartitionedState(
+              VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
+    }
   }
 
   @Override
   public Stream<T> getElements() {
+    if(state == null) return Stream.empty();
     return backend
         .getKeys(stateName, VoidNamespace.INSTANCE)
         .flatMap(
@@ -80,6 +88,7 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
 
   @Override
   public void clear() throws Exception {
+    if (state == null) return;
     // TODO we have to collect all keys because otherwise we get ConcurrentModificationExceptions
     // from flink. We can change this once it's fixed in Flink
     List<K> keys = backend.getKeys(stateName, VoidNamespace.INSTANCE).collect(Collectors.toList());
@@ -92,14 +101,20 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
 
   @Override
   public void pushBack(T element) throws Exception {
+    ensureStateInitialized();
+    pushBack0(element);
+  }
+
+  public void pushBack0(T element) throws Exception {
     backend.setCurrentKey(keySelector.getKey(element));
     state.add(element);
   }
 
   @Override
   public void pushBackAll(Iterable<T> elements) throws Exception {
+    ensureStateInitialized();
     for (T e : elements) {
-      pushBack(e);
+      pushBack0(e);
     }
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
@@ -66,14 +66,17 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
   public Stream<T> getElements() {
     if (state != null) {
       final ListState<T> s = state;
-      return backend.getKeys(stateName, VoidNamespace.INSTANCE).flatMap(key -> {
-        try {
-          backend.setCurrentKey(key);
-          return StreamSupport.stream(s.get().spliterator(), false);
-        } catch (Exception e) {
-          throw new RuntimeException("Error reading keyed state.", e);
-        }
-      });
+      return backend
+          .getKeys(stateName, VoidNamespace.INSTANCE)
+          .flatMap(
+              key -> {
+                try {
+                  backend.setCurrentKey(key);
+                  return StreamSupport.stream(s.get().spliterator(), false);
+                } catch (Exception e) {
+                  throw new RuntimeException("Error reading keyed state.", e);
+                }
+              });
     } else {
       return Stream.empty();
     }
@@ -85,7 +88,8 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
       final ListState<T> s = state;
       // TODO we have to collect all keys because otherwise we get ConcurrentModificationExceptions
       // from flink. We can change this once it's fixed in Flink
-      List<K> keys = backend.getKeys(stateName, VoidNamespace.INSTANCE).collect(Collectors.toList());
+      List<K> keys =
+          backend.getKeys(stateName, VoidNamespace.INSTANCE).collect(Collectors.toList());
 
       for (K key : keys) {
         backend.setCurrentKey(key);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import javax.annotation.Nullable;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -48,7 +49,7 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
   private final KeyedStateBackend<K> backend;
   private final String stateName;
   private final ListStateDescriptor<T> stateDescriptor;
-  private ListState<T> state;
+  @Nullable private ListState<T> state;
 
   private KeyedPushedBackElementsHandler(
       KeySelector<T, K> keySelector,
@@ -61,25 +62,17 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
     this.stateDescriptor = Objects.requireNonNull(stateDescriptor);
   }
 
-  private void ensureStateInitialized() throws Exception {
-    if (state == null) {
-      // Eagerly retrieve the state to work around https://jira.apache.org/jira/browse/FLINK-12653
-      this.state =
-          backend.getPartitionedState(
-              VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
-    }
-  }
-
   @Override
   public Stream<T> getElements() {
     if (state == null) return Stream.empty();
+    final ListState<T> s = state;
     return backend
         .getKeys(stateName, VoidNamespace.INSTANCE)
         .flatMap(
             key -> {
               try {
                 backend.setCurrentKey(key);
-                return StreamSupport.stream(state.get().spliterator(), false);
+                return StreamSupport.stream(s.get().spliterator(), false);
               } catch (Exception e) {
                 throw new RuntimeException("Error reading keyed state.", e);
               }
@@ -89,32 +82,42 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
   @Override
   public void clear() throws Exception {
     if (state == null) return;
+    final ListState<T> s = state;
     // TODO we have to collect all keys because otherwise we get ConcurrentModificationExceptions
     // from flink. We can change this once it's fixed in Flink
     List<K> keys = backend.getKeys(stateName, VoidNamespace.INSTANCE).collect(Collectors.toList());
 
     for (K key : keys) {
       backend.setCurrentKey(key);
-      state.clear();
+      s.clear();
     }
   }
 
   @Override
   public void pushBack(T element) throws Exception {
-    ensureStateInitialized();
-    pushBack0(element);
-  }
-
-  private void pushBack0(T element) throws Exception {
+    if (state == null) {
+      // Eagerly retrieve the state to work around https://jira.apache.org/jira/browse/FLINK-12653
+      this.state =
+          backend.getPartitionedState(
+              VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
+    }
+    final ListState<T> s = state;
     backend.setCurrentKey(keySelector.getKey(element));
-    state.add(element);
+    s.add(element);
   }
 
   @Override
   public void pushBackAll(Iterable<T> elements) throws Exception {
-    ensureStateInitialized();
+    if (state == null) {
+      // Eagerly retrieve the state to work around https://jira.apache.org/jira/browse/FLINK-12653
+      this.state =
+          backend.getPartitionedState(
+              VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
+    }
+    final ListState<T> s = state;
     for (T e : elements) {
-      pushBack0(e);
+      backend.setCurrentKey(keySelector.getKey(e));
+      s.add(e);
     }
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
@@ -62,8 +62,9 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
     // check if the state is restored from a checkpoint
     if (this.backend.getKeys(stateDescriptor.getName(), VoidNamespace.INSTANCE).count() > 0) {
       // Eagerly retrieve the state to work around https://jira.apache.org/jira/browse/FLINK-12653
-      this.elementState = backend.getPartitionedState(
-          VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
+      this.elementState =
+          backend.getPartitionedState(
+              VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
     }
   }
 
@@ -74,15 +75,17 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
     }
 
     final ListState<T> state = elementState;
-    return backend.getKeys(stateDescriptor.getName(), VoidNamespace.INSTANCE)
-        .flatMap(key -> {
-          try {
-            backend.setCurrentKey(key);
-            return StreamSupport.stream(state.get().spliterator(), false);
-          } catch (Exception e) {
-            throw new RuntimeException("Error reading keyed state.", e);
-          }
-        });
+    return backend
+        .getKeys(stateDescriptor.getName(), VoidNamespace.INSTANCE)
+        .flatMap(
+            key -> {
+              try {
+                backend.setCurrentKey(key);
+                return StreamSupport.stream(state.get().spliterator(), false);
+              } catch (Exception e) {
+                throw new RuntimeException("Error reading keyed state.", e);
+              }
+            });
   }
 
   @Override
@@ -92,7 +95,9 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
       // TODO we have to collect all keys because otherwise we get ConcurrentModificationExceptions
       // from flink. We can change this once it's fixed in Flink
       List<K> keys =
-          backend.getKeys(stateDescriptor.getName(), VoidNamespace.INSTANCE).collect(Collectors.toList());
+          backend
+              .getKeys(stateDescriptor.getName(), VoidNamespace.INSTANCE)
+              .collect(Collectors.toList());
 
       for (K key : keys) {
         backend.setCurrentKey(key);
@@ -119,8 +124,9 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
 
   private ListState<T> getOrCreateState() throws Exception {
     if (elementState == null) {
-      this.elementState = backend.getPartitionedState(
-          VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
+      this.elementState =
+          backend.getPartitionedState(
+              VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
     }
     return elementState;
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
@@ -72,7 +72,7 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
 
   @Override
   public Stream<T> getElements() {
-    if(state == null) return Stream.empty();
+    if (state == null) return Stream.empty();
     return backend
         .getKeys(stateName, VoidNamespace.INSTANCE)
         .flatMap(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/NonKeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/NonKeyedPushedBackElementsHandler.java
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.state.OperatorStateBackend;
 class NonKeyedPushedBackElementsHandler<T> implements PushedBackElementsHandler<T> {
 
   static <T> NonKeyedPushedBackElementsHandler<T> create(
-      OperatorStateBackend backend, ListStateDescriptor<T> stateDescriptor) {
+      OperatorStateBackend backend, ListStateDescriptor<T> stateDescriptor) throws Exception {
     return new NonKeyedPushedBackElementsHandler<>(backend, stateDescriptor);
   }
 
@@ -39,18 +39,18 @@ class NonKeyedPushedBackElementsHandler<T> implements PushedBackElementsHandler<
   @Nullable private ListState<T> elementState;
 
   private NonKeyedPushedBackElementsHandler(
-      OperatorStateBackend backend, ListStateDescriptor<T> stateDescriptor) {
+      OperatorStateBackend backend, ListStateDescriptor<T> stateDescriptor) throws Exception {
     this.backend = checkNotNull(backend);
     this.stateDescriptor = checkNotNull(stateDescriptor);
+    // check if the state is restored from a checkpoint
+    if (backend.getRegisteredStateNames().contains(stateDescriptor.getName())) {
+      elementState = backend.getListState(stateDescriptor);
+    }
   }
 
   @Override
   public Stream<T> getElements() throws Exception {
-    if (elementState != null) {
-      return StreamSupport.stream(elementState.get().spliterator(), false);
-    } else {
-      return Stream.empty();
-    }
+    return elementState == null ? Stream.empty() : StreamSupport.stream(elementState.get().spliterator(), false);
   }
 
   @Override
@@ -62,21 +62,21 @@ class NonKeyedPushedBackElementsHandler<T> implements PushedBackElementsHandler<
 
   @Override
   public void pushBack(T element) throws Exception {
-    if (elementState == null) {
-      elementState = backend.getListState(stateDescriptor);
-    }
-    elementState.add(element);
+    getOrCreateState().add(element);
   }
 
   @Override
   public void pushBackAll(Iterable<T> elements) throws Exception {
+    ListState<T> state = getOrCreateState();
+    for (T e : elements) {
+      state.add(e);
+    }
+  }
+
+  private ListState<T> getOrCreateState() throws Exception {
     if (elementState == null) {
       elementState = backend.getListState(stateDescriptor);
     }
-    final ListState<T> state = elementState;
-    for (T e : elements) {
-      // TODO: use addAll() once Flink has addAll(Iterable<T>)
-      state.add(e);
-    }
+    return elementState;
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/NonKeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/NonKeyedPushedBackElementsHandler.java
@@ -21,6 +21,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import javax.annotation.Nullable;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.runtime.state.OperatorStateBackend;
@@ -35,18 +36,12 @@ class NonKeyedPushedBackElementsHandler<T> implements PushedBackElementsHandler<
 
   private final OperatorStateBackend backend;
   private final ListStateDescriptor<T> stateDescriptor;
-  private ListState<T> elementState;
+  @Nullable private ListState<T> elementState;
 
   private NonKeyedPushedBackElementsHandler(
       OperatorStateBackend backend, ListStateDescriptor<T> stateDescriptor) {
     this.backend = checkNotNull(backend);
     this.stateDescriptor = checkNotNull(stateDescriptor);
-  }
-
-  private void ensureStateInitialized() throws Exception {
-    if (elementState == null) {
-      elementState = backend.getListState(stateDescriptor);
-    }
   }
 
   @Override
@@ -57,22 +52,28 @@ class NonKeyedPushedBackElementsHandler<T> implements PushedBackElementsHandler<
 
   @Override
   public void clear() throws Exception {
-    if (elementState == null) return;
-    elementState.clear();
+    if (elementState != null) {
+      elementState.clear();
+    }
   }
 
   @Override
   public void pushBack(T element) throws Exception {
-    ensureStateInitialized();
+    if (elementState == null) {
+      elementState = backend.getListState(stateDescriptor);
+    }
     elementState.add(element);
   }
 
   @Override
   public void pushBackAll(Iterable<T> elements) throws Exception {
-    ensureStateInitialized();
+    if (elementState == null) {
+      elementState = backend.getListState(stateDescriptor);
+    }
+    final ListState<T> state = elementState;
     for (T e : elements) {
       // TODO: use addAll() once Flink has addAll(Iterable<T>)
-      elementState.add(e);
+      state.add(e);
     }
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/NonKeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/NonKeyedPushedBackElementsHandler.java
@@ -46,8 +46,11 @@ class NonKeyedPushedBackElementsHandler<T> implements PushedBackElementsHandler<
 
   @Override
   public Stream<T> getElements() throws Exception {
-    if (elementState == null) return Stream.empty();
-    return StreamSupport.stream(elementState.get().spliterator(), false);
+    if (elementState != null) {
+      return StreamSupport.stream(elementState.get().spliterator(), false);
+    } else {
+      return Stream.empty();
+    }
   }
 
   @Override

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/NonKeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/NonKeyedPushedBackElementsHandler.java
@@ -29,8 +29,7 @@ import org.apache.flink.runtime.state.OperatorStateBackend;
 class NonKeyedPushedBackElementsHandler<T> implements PushedBackElementsHandler<T> {
 
   static <T> NonKeyedPushedBackElementsHandler<T> create(
-      OperatorStateBackend backend,
-      ListStateDescriptor<T> stateDescriptor) {
+      OperatorStateBackend backend, ListStateDescriptor<T> stateDescriptor) {
     return new NonKeyedPushedBackElementsHandler<>(backend, stateDescriptor);
   }
 
@@ -39,8 +38,7 @@ class NonKeyedPushedBackElementsHandler<T> implements PushedBackElementsHandler<
   private ListState<T> elementState;
 
   private NonKeyedPushedBackElementsHandler(
-      OperatorStateBackend backend,
-      ListStateDescriptor<T> stateDescriptor) {
+      OperatorStateBackend backend, ListStateDescriptor<T> stateDescriptor) {
     this.backend = checkNotNull(backend);
     this.stateDescriptor = checkNotNull(stateDescriptor);
   }
@@ -53,7 +51,7 @@ class NonKeyedPushedBackElementsHandler<T> implements PushedBackElementsHandler<
 
   @Override
   public Stream<T> getElements() throws Exception {
-    if(elementState == null) return Stream.empty();
+    if (elementState == null) return Stream.empty();
     return StreamSupport.stream(elementState.get().spliterator(), false);
   }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/NonKeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/NonKeyedPushedBackElementsHandler.java
@@ -22,37 +22,56 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.runtime.state.OperatorStateBackend;
 
 /** {@link PushedBackElementsHandler} that stores elements in a Flink operator state list. */
 class NonKeyedPushedBackElementsHandler<T> implements PushedBackElementsHandler<T> {
 
-  static <T> NonKeyedPushedBackElementsHandler<T> create(ListState<T> elementState) {
-    return new NonKeyedPushedBackElementsHandler<>(elementState);
+  static <T> NonKeyedPushedBackElementsHandler<T> create(
+      OperatorStateBackend backend,
+      ListStateDescriptor<T> stateDescriptor) {
+    return new NonKeyedPushedBackElementsHandler<>(backend, stateDescriptor);
   }
 
-  private final ListState<T> elementState;
+  private final OperatorStateBackend backend;
+  private final ListStateDescriptor<T> stateDescriptor;
+  private ListState<T> elementState;
 
-  private NonKeyedPushedBackElementsHandler(ListState<T> elementState) {
-    this.elementState = checkNotNull(elementState);
+  private NonKeyedPushedBackElementsHandler(
+      OperatorStateBackend backend,
+      ListStateDescriptor<T> stateDescriptor) {
+    this.backend = checkNotNull(backend);
+    this.stateDescriptor = checkNotNull(stateDescriptor);
+  }
+
+  private void ensureStateInitialized() throws Exception {
+    if (elementState == null) {
+      elementState = backend.getListState(stateDescriptor);
+    }
   }
 
   @Override
   public Stream<T> getElements() throws Exception {
+    if(elementState == null) return Stream.empty();
     return StreamSupport.stream(elementState.get().spliterator(), false);
   }
 
   @Override
-  public void clear() {
+  public void clear() throws Exception {
+    if (elementState == null) return;
     elementState.clear();
   }
 
   @Override
   public void pushBack(T element) throws Exception {
+    ensureStateInitialized();
     elementState.add(element);
   }
 
   @Override
   public void pushBackAll(Iterable<T> elements) throws Exception {
+    ensureStateInitialized();
     for (T e : elements) {
       // TODO: use addAll() once Flink has addAll(Iterable<T>)
       elementState.add(e);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/NonKeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/NonKeyedPushedBackElementsHandler.java
@@ -50,7 +50,9 @@ class NonKeyedPushedBackElementsHandler<T> implements PushedBackElementsHandler<
 
   @Override
   public Stream<T> getElements() throws Exception {
-    return elementState == null ? Stream.empty() : StreamSupport.stream(elementState.get().spliterator(), false);
+    return elementState == null
+        ? Stream.empty()
+        : StreamSupport.stream(elementState.get().spliterator(), false);
   }
 
   @Override

--- a/website/www/site/layouts/shortcodes/flink_java_pipeline_options.html
+++ b/website/www/site/layouts/shortcodes/flink_java_pipeline_options.html
@@ -88,11 +88,6 @@ Should be called before running the tests.
   <td></td>
 </tr>
 <tr>
-  <td><code>flinkConfMap</code></td>
-  <td>Map containing Flink configurations</td>
-  <td></td>
-</tr>
-<tr>
   <td><code>flinkMaster</code></td>
   <td>Address of the Flink Master where the Pipeline should be executed. Can either be of the form "host:port" or one of the special values [local], [collection] or [auto].</td>
   <td>Default: <code>[auto]</code></td>

--- a/website/www/site/layouts/shortcodes/flink_python_pipeline_options.html
+++ b/website/www/site/layouts/shortcodes/flink_python_pipeline_options.html
@@ -88,11 +88,6 @@ Should be called before running the tests.
   <td></td>
 </tr>
 <tr>
-  <td><code>flink_conf_map</code></td>
-  <td>Map containing Flink configurations</td>
-  <td></td>
-</tr>
-<tr>
   <td><code>flink_master</code></td>
   <td>Address of the Flink Master where the Pipeline should be executed. Can either be of the form "host:port" or one of the special values [local], [collection] or [auto].</td>
   <td>Default: <code>[auto]</code></td>


### PR DESCRIPTION
The  DoFnOperator always registers two states with the state backend:  `bundle-buffer-tag` and `pushed-back-elements`, regardless of whether the operator  is stateless or stateful. These states are managed via either 
KeyedPushedBackElementsHandler or NonKeyedPushedBackElementsHandler.

This change delays state registration until elements are actually pushed back.  This avoids unnecessary state persistence for stateless operators for Flink jobs, reducing  checkpoint size and improving performance.

This behavior change applies to both Keyed and NonKeyed pushed-back element handlers.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
