### PR TITLE
include global metrics in updateMetrics for Flink Runner

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.47'
+    project.version = '2.45.48'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.47
-sdk_version=2.45.47
+version=2.45.48
+sdk_version=2.45.48
 
 javaVersion=1.8
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerBase.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerBase.java
@@ -17,16 +17,11 @@
  */
 package org.apache.beam.runners.flink.metrics;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.model.pipeline.v1.MetricsApi;
-import org.apache.beam.runners.core.metrics.DefaultMetricResults;
-import org.apache.beam.runners.core.metrics.DistributionData;
-import org.apache.beam.runners.core.metrics.GaugeData;
-import org.apache.beam.runners.core.metrics.MetricUpdates;
 import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
 import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
 import org.apache.beam.sdk.metrics.DistributionResult;
@@ -88,10 +83,7 @@ abstract class FlinkMetricContainerBase {
    * given step.
    */
   void updateMetrics(String stepName) {
-    List<String> stepNameList =
-        Arrays.asList(stepName, GlobalMetricsUtils.GLOBAL_CONTAINER_STEP_NAME);
-    MetricResults metricResults =
-        asAttemptedOnlyMetricResultsForSteps(metricsContainers, stepNameList);
+    MetricResults metricResults = MetricsContainerStepMap.asAttemptedOnlyMetricResults(metricsContainers);
     MetricQueryResults metricQueryResults =
         metricResults.queryMetrics(
             MetricsFilter.builder()
@@ -101,44 +93,6 @@ abstract class FlinkMetricContainerBase {
     updateCounters(metricQueryResults.getCounters());
     updateDistributions(metricQueryResults.getDistributions());
     updateGauge(metricQueryResults.getGauges());
-  }
-
-  /**
-   * Similar to {@link MetricsContainerStepMap#asAttemptedOnlyMetricResults}, it gets the metrics
-   * results from the MetricsContainerStepMap. Instead of getting from all steps, it gets result
-   * from only interested steps. Thus, it's more efficient.
-   */
-  private static MetricResults asAttemptedOnlyMetricResultsForSteps(
-      MetricsContainerStepMap metricsContainers, List<String> steps) {
-    List<MetricResult<Long>> counters = new ArrayList<>();
-    List<MetricResult<GaugeResult>> gauges = new ArrayList<>();
-    List<MetricResult<DistributionResult>> distributions = new ArrayList<>();
-
-    for (String step : steps) {
-      MetricsContainerImpl container = metricsContainers.getContainer(step);
-      MetricUpdates cumulative = container.getUpdates();
-
-      // Merging counters
-      for (MetricUpdates.MetricUpdate<Long> counterUpdate : cumulative.counterUpdates()) {
-        counters.add(MetricResult.attempted(counterUpdate.getKey(), counterUpdate.getUpdate()));
-      }
-
-      // Merging distributions
-      for (MetricUpdates.MetricUpdate<DistributionData> distributionUpdate :
-          cumulative.distributionUpdates()) {
-        distributions.add(
-            MetricResult.attempted(
-                distributionUpdate.getKey(), distributionUpdate.getUpdate().extractResult()));
-      }
-
-      // Merging gauges
-      for (MetricUpdates.MetricUpdate<GaugeData> gaugeUpdate : cumulative.gaugeUpdates()) {
-        gauges.add(
-            MetricResult.attempted(gaugeUpdate.getKey(), gaugeUpdate.getUpdate().extractResult()));
-      }
-    }
-
-    return new DefaultMetricResults(counters, distributions, gauges);
   }
 
   private void updateCounters(Iterable<MetricResult<Long>> counters) {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerBase.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerBase.java
@@ -19,10 +19,16 @@ package org.apache.beam.runners.flink.metrics;
 
 import static org.apache.beam.runners.core.metrics.MetricsContainerStepMap.asAttemptedOnlyMetricResults;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.model.pipeline.v1.MetricsApi;
+import org.apache.beam.runners.core.metrics.DefaultMetricResults;
+import org.apache.beam.runners.core.metrics.DistributionData;
+import org.apache.beam.runners.core.metrics.GaugeData;
+import org.apache.beam.runners.core.metrics.MetricUpdates;
 import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
 import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
 import org.apache.beam.sdk.metrics.DistributionResult;
@@ -84,14 +90,57 @@ abstract class FlinkMetricContainerBase {
    * given step.
    */
   void updateMetrics(String stepName) {
-    MetricResults metricResults = asAttemptedOnlyMetricResults(metricsContainers);
+    List<String> stepNameList = Arrays.asList(stepName, GlobalMetricsUtils.GLOBAL_CONTAINER_STEP_NAME);
+    MetricResults metricResults =
+        asAttemptedOnlyMetricResultsForSteps(metricsContainers, stepNameList);
     MetricQueryResults metricQueryResults =
-        metricResults.queryMetrics(MetricsFilter.builder().addStep(stepName).build());
+        metricResults.queryMetrics(
+            MetricsFilter.builder()
+                .addStep(stepName)
+                .addStep(GlobalMetricsUtils.GLOBAL_CONTAINER_STEP_NAME)
+                .build());
     updateCounters(metricQueryResults.getCounters());
     updateDistributions(metricQueryResults.getDistributions());
     updateGauge(metricQueryResults.getGauges());
   }
 
+  /**
+   * Similar to {@link MetricsContainerStepMap#asAttemptedOnlyMetricResults}, it gets the metrics
+   * results from the MetricsContainerStepMap. Instead of getting from all steps, it gets result
+   * from only interested steps. Thus, it's more efficient.
+   */
+  private static MetricResults asAttemptedOnlyMetricResultsForSteps(
+      MetricsContainerStepMap metricsContainers, List<String> steps) {
+    List<MetricResult<Long>> counters = new ArrayList<>();
+    List<MetricResult<GaugeResult>> gauges = new ArrayList<>();
+    List<MetricResult<DistributionResult>> distributions = new ArrayList<>();
+
+    for (String step : steps) {
+      MetricsContainerImpl container = metricsContainers.getContainer(step);
+      MetricUpdates cumulative = container.getUpdates();
+
+      // Merging counters
+      for (MetricUpdates.MetricUpdate<Long> counterUpdate : cumulative.counterUpdates()) {
+        counters.add(MetricResult.attempted(counterUpdate.getKey(), counterUpdate.getUpdate()));
+      }
+
+      // Merging distributions
+      for (MetricUpdates.MetricUpdate<DistributionData> distributionUpdate :
+          cumulative.distributionUpdates()) {
+        distributions.add(
+            MetricResult.attempted(
+                distributionUpdate.getKey(), distributionUpdate.getUpdate().extractResult()));
+      }
+
+      // Merging gauges
+      for (MetricUpdates.MetricUpdate<GaugeData> gaugeUpdate : cumulative.gaugeUpdates()) {
+        gauges.add(
+            MetricResult.attempted(gaugeUpdate.getKey(), gaugeUpdate.getUpdate().extractResult()));
+      }
+    }
+
+    return new DefaultMetricResults(counters, distributions, gauges);
+  }
   private void updateCounters(Iterable<MetricResult<Long>> counters) {
     for (MetricResult<Long> metricResult : counters) {
       String flinkMetricName = getFlinkMetricNameString(metricResult.getKey());

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerBase.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerBase.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.runners.flink.metrics;
 
-import static org.apache.beam.runners.core.metrics.MetricsContainerStepMap.asAttemptedOnlyMetricResults;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -90,7 +88,8 @@ abstract class FlinkMetricContainerBase {
    * given step.
    */
   void updateMetrics(String stepName) {
-    List<String> stepNameList = Arrays.asList(stepName, GlobalMetricsUtils.GLOBAL_CONTAINER_STEP_NAME);
+    List<String> stepNameList =
+        Arrays.asList(stepName, GlobalMetricsUtils.GLOBAL_CONTAINER_STEP_NAME);
     MetricResults metricResults =
         asAttemptedOnlyMetricResultsForSteps(metricsContainers, stepNameList);
     MetricQueryResults metricQueryResults =
@@ -141,6 +140,7 @@ abstract class FlinkMetricContainerBase {
 
     return new DefaultMetricResults(counters, distributions, gauges);
   }
+
   private void updateCounters(Iterable<MetricResult<Long>> counters) {
     for (MetricResult<Long> metricResult : counters) {
       String flinkMetricName = getFlinkMetricNameString(metricResult.getKey());

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerBase.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerBase.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.runners.flink.metrics;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,7 +82,8 @@ abstract class FlinkMetricContainerBase {
    * given step.
    */
   void updateMetrics(String stepName) {
-    MetricResults metricResults = MetricsContainerStepMap.asAttemptedOnlyMetricResults(metricsContainers);
+    MetricResults metricResults =
+        MetricsContainerStepMap.asAttemptedOnlyMetricResults(metricsContainers);
     MetricQueryResults metricQueryResults =
         metricResults.queryMetrics(
             MetricsFilter.builder()

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/GlobalMetricsUtils.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/GlobalMetricsUtils.java
@@ -21,7 +21,7 @@ import org.apache.beam.sdk.metrics.MetricsEnvironment;
 
 /** Utility class for managing global metrics in a Flink environment. */
 public class GlobalMetricsUtils {
-  private static final String GLOBAL_CONTAINER_STEP_NAME = "GLOBAL_METRICS";
+  static final String GLOBAL_CONTAINER_STEP_NAME = "GLOBAL_METRICS";
 
   /**
    * Sets the global metrics container if it is not already set.


### PR DESCRIPTION
## Background
Metrics emission in non-processing thread is generally not supported in Beam.In Samza Runner, we added the support for Global Metrics which allow metrics emitted in non-processing thread to be collected through a global metrics container.
We want to add similar support for Global Metrics in Flink Runner. Currently a missing piece is that in the `updateMetrics` stage, propagation of Beam metics into Flink metrics system is done by step/transform and does not include global metrics.

## Changes
This change ensures that metrics from `GLOBAL_METRICS` step are also propagated into Flink’s metric system. `updateMetrics` now aggregates and queries metrics for both the per-step container and the global container, so global metrics become visible alongside step-specific metrics in Flink.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
