### PR TITLE
prevent deadlock when customPipelineOptions.as are called from different threads

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.49'
+    project.version = '2.45.50'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.48'
+    project.version = '2.45.49'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.49
-sdk_version=2.45.49
+version=2.45.50
+sdk_version=2.45.50
 
 javaVersion=1.8
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.48
-sdk_version=2.45.48
+version=2.45.49
+sdk_version=2.45.49
 
 javaVersion=1.8
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -99,6 +99,8 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
    */
   private final int hashCode = ThreadLocalRandom.current().nextInt();
 
+  private static final Object LOCK = new Object();
+
   private static final class ComputedProperties {
     final ImmutableClassToInstanceMap<PipelineOptions> interfaceToProxyCache;
     final ImmutableMap<String, String> gettersToPropertyNames;
@@ -140,7 +142,7 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
     }
   }
 
-  /** Only modified while holding a lock on {@code this}. */
+  /** Only modified while holding {@code LOCK}. */
   @SuppressFBWarnings("SE_BAD_FIELD")
   private volatile ComputedProperties computedProperties;
 
@@ -298,7 +300,7 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
     // LI-SPECIFIC CHANGE to ensure only one thread can read and write of PipelineOptions
 
     // Fast path: return cached proxy under lock
-    synchronized (this) {
+    synchronized (LOCK) {
       T existingOption = computedProperties.interfaceToProxyCache.getInstance(iface);
       if (existingOption != null) {
         return existingOption;
@@ -328,7 +330,7 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
     }
 
     // Re-acquire lock to update cache; double-check in case another thread raced us
-    synchronized (this) {
+    synchronized (LOCK) {
       T existingOption = computedProperties.interfaceToProxyCache.getInstance(iface);
       if (existingOption != null) {
         return existingOption;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -323,6 +323,7 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
             .build();
 
     if (pipelineOptions != null && CustomPipelineOptionsInitializer.get() != null) {
+      // Linkedin specific change: initialize the offspring generator
       newOption = (T) CustomPipelineOptionsInitializer.get().init(newOption, iface);
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -296,33 +296,45 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
     checkArgument(iface.isInterface(), "Not an interface: %s", iface);
 
     // LI-SPECIFIC CHANGE to ensure only one thread can read and write of PipelineOptions
+
+    // Fast path: return cached proxy under lock
     synchronized (this) {
       T existingOption = computedProperties.interfaceToProxyCache.getInstance(iface);
-
-      if (existingOption == null) {
-        Registration<T> registration =
-            PipelineOptionsFactory.CACHE
-                .get()
-                .validateWellFormed(iface, computedProperties.knownInterfaces);
-        List<PropertyDescriptor> propertyDescriptors = registration.getPropertyDescriptors();
-
-        Class<T> proxyClass = registration.getProxyClass();
-
-        existingOption =
-            InstanceBuilder.ofType(proxyClass)
-                .fromClass(proxyClass)
-                .withArg(InvocationHandler.class, this)
-                .build();
-
-        // Linkedin specific change: initialize the offspring generator
-        if (pipelineOptions != null && CustomPipelineOptionsInitializer.get() != null) {
-          existingOption = (T) CustomPipelineOptionsInitializer.get().init(existingOption, iface);
-        }
-
-        computedProperties =
-            computedProperties.updated(iface, existingOption, propertyDescriptors);
+      if (existingOption != null) {
+        return existingOption;
       }
-      return existingOption;
+    }
+
+    // Slow path: create proxy and run initializer OUTSIDE the lock.
+    // The initializer may dispatch work to other threads (e.g.,FlinkGeneratorHelper.getBean)
+    // that need to re-enter as() on this handler, so the lock must not be held here.
+    Registration<T> registration =
+        PipelineOptionsFactory.CACHE
+            .get()
+            .validateWellFormed(iface, computedProperties.knownInterfaces);
+    List<PropertyDescriptor> propertyDescriptors =
+        registration.getPropertyDescriptors();
+    Class<T> proxyClass = registration.getProxyClass();
+
+    T newOption =
+        InstanceBuilder.ofType(proxyClass)
+            .fromClass(proxyClass)
+            .withArg(InvocationHandler.class, this)
+            .build();
+
+    if (pipelineOptions != null && CustomPipelineOptionsInitializer.get() != null) {
+      newOption = (T) CustomPipelineOptionsInitializer.get().init(newOption, iface);
+    }
+
+    // Re-acquire lock to update cache; double-check in case another thread raced us
+    synchronized (this) {
+      T existingOption = computedProperties.interfaceToProxyCache.getInstance(iface);
+      if (existingOption != null) {
+        return existingOption;
+      }
+      computedProperties =
+          computedProperties.updated(iface, newOption, propertyDescriptors);
+      return newOption;
     }
   }
 


### PR DESCRIPTION
**Prevent deadlock in ProxyInvocationHandler.as() when called from multiple threads**

  The `as()` method in `ProxyInvocationHandler` previously held the synchronized lock for the entire duration of proxy creation and initialization. This caused a deadlock when
  `CustomPipelineOptionsInitializer.init()` dispatched work to other threads (e.g., `FlinkGeneratorHelper.getBean`) that needed to re-enter `as()` on the same handler.

  Fix: Adopt a double-checked locking pattern:
  1. Fast path — return the cached proxy under the lock if it already exists.
  2. Slow path — release the lock, create the proxy and run the initializer outside the lock, then re-acquire the lock to update the cache (with a second check for races).

  This ensures the initializer can safely trigger nested as() calls from different threads without deadlocking.

  Also bumps version from 2.45.48 to 2.45.49.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
