### PR TITLE
fix Serializer Mismatch Between EarlyBinder and FlinkSetState

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.48'
+    project.version = '2.45.49'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.48
-sdk_version=2.45.48
+version=2.45.49
+sdk_version=2.45.49
 
 javaVersion=1.8
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -1611,7 +1611,7 @@ public class FlinkStateInternals<K> implements StateInternals {
             new MapStateDescriptor<>(
                 id,
                 new CoderTypeSerializer<>(elemCoder, pipelineOptions),
-                new BooleanSerializer()));
+                BooleanSerializer.INSTANCE));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -76,7 +76,6 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.BooleanSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.api.common.typeutils.base.VoidSerializer;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
@@ -1612,7 +1611,7 @@ public class FlinkStateInternals<K> implements StateInternals {
             new MapStateDescriptor<>(
                 id,
                 new CoderTypeSerializer<>(elemCoder, pipelineOptions),
-                VoidSerializer.INSTANCE));
+                new BooleanSerializer()));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkStateInternalsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkStateInternalsTest.java
@@ -19,6 +19,8 @@ package org.apache.beam.runners.flink.streaming;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -33,6 +35,8 @@ import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkStateInternals;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.state.SetState;
+import org.apache.beam.sdk.state.StateSpecs;
 import org.apache.beam.sdk.state.WatermarkHoldState;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
@@ -182,6 +186,62 @@ public class FlinkStateInternalsTest extends StateInternalsTest {
     state.add(now);
     stateInternals.clearGlobalState();
     assertThat(state.read(), is((Instant) null));
+  }
+
+  /**
+   * Tests that SetState works correctly when EarlyBinder pre-registers the state before
+   * FlinkStateInternals accesses it. This simulates the production flow in DoFnOperator where
+   * earlyBindStateIfNeeded() runs first to work around FLINK-12653. A serializer mismatch between
+   * EarlyBinder and FlinkSetState would cause a ClassCastException.
+   */
+  @Test
+  public void testSetStateAfterEarlyBinding() throws Exception {
+    KeyedStateBackend<ByteBuffer> keyedStateBackend = createStateBackend();
+    SerializablePipelineOptions pipelineOptions =
+        new SerializablePipelineOptions(FlinkPipelineOptions.defaults());
+
+    // Step 1: EarlyBinder pre-registers the state (same as DoFnOperator.earlyBindStateIfNeeded)
+    FlinkStateInternals.EarlyBinder earlyBinder =
+        new FlinkStateInternals.EarlyBinder(keyedStateBackend, pipelineOptions);
+    StateSpecs.set(StringUtf8Coder.of()).bind("testSet", earlyBinder);
+
+    // Step 2: Create FlinkStateInternals and access the same state
+    FlinkStateInternals<String> stateInternals =
+        new FlinkStateInternals<>(
+            keyedStateBackend,
+            StringUtf8Coder.of(),
+            new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
+
+    StateTag<SetState<String>> setStateTag = StateTags.set("testSet", StringUtf8Coder.of());
+    SetState<String> setState = stateInternals.state(StateNamespaces.global(), setStateTag);
+
+    // Step 3: Verify all SetState operations work without ClassCastException
+    assertThat(setState.read(), is(Matchers.emptyIterable()));
+    assertFalse(setState.contains("A").read());
+
+    // add
+    setState.add("A");
+    assertTrue(setState.contains("A").read());
+    assertFalse(setState.contains("B").read());
+
+    setState.add("B");
+    assertTrue(setState.contains("A").read());
+    assertTrue(setState.contains("B").read());
+
+    // addIfAbsent
+    assertFalse(setState.addIfAbsent("A").read());
+    assertTrue(setState.addIfAbsent("C").read());
+    assertTrue(setState.contains("C").read());
+
+    // remove
+    setState.remove("B");
+    assertFalse(setState.contains("B").read());
+    assertTrue(setState.contains("A").read());
+    assertTrue(setState.contains("C").read());
+
+    // clear
+    setState.clear();
+    assertThat(setState.read(), is(Matchers.emptyIterable()));
   }
 
   public static KeyedStateBackend<ByteBuffer> createStateBackend() throws Exception {


### PR DESCRIPTION
## The Error
We see some job fails on Flink with `ClassCastException: class java.lang.Boolean cannot be cast to class java.lang.Void` `whenever SetState.add` is called.

## How Beam's SetState Works on Flink
Beam's SetState<T> is an abstraction — "I want a set of values in my state." Flink doesn't have a native set state, so the Beam Flink runner implements it as a MapState<T, Boolean> — keys are the set elements, values are true (just a marker). This is defined in FlinkSetState:
```
// FlinkSetState constructor (line 1410-1412)
new MapStateDescriptor<>(stateId, CoderTypeSerializer, new BooleanSerializer())

 // add() stores true as the value (line 1468)
  state.put(value, true);
```

This is internally consistent.

However There's a second class called EarlyBinder that pre-registers all state descriptors with Flink's KeyedStateBackend during operator initialization. This exists to work around https://jira.apache.org/jira/browse/FLINK-12653. It runs before FlinkSetState is ever constructed.

The problem is EarlyBinder.bindSet registers the state with the wrong serializer:
```
  // EarlyBinder.bindSet (line 1612-1615) — runs FIRST
  new MapStateDescriptor<>(id, CoderTypeSerializer, VoidSerializer.INSTANCE)  // <-- Void!

  // FlinkSetState constructor (line 1410-1412) — runs LATER
  new MapStateDescriptor<>(stateId, CoderTypeSerializer, new BooleanSerializer())  // <-- Boolean!
```

## What Happens at Runtime
  1. Operator initialization: EarlyBinder.bindSet calls getOrCreateKeyedState(), which registers the MapState in Flink's KeyedStateBackend with VoidSerializer as the value serializer.
  2. Message processing: FlinkSetState.add() calls getPartitionedState() with a descriptor that has BooleanSerializer. But Flink's state backend looks up the state by name and returns the one already registered by EarlyBinder — whose internal serializer is still VoidSerializer.
  3. Serialization: state.put(key, true) is called. RocksDB needs to serialize the value true (a Boolean). It uses the runtime serializer (VoidSerializer) which casts the value to Void: `VoidSerializer.serialize(Boolean) → ClassCastException`

## Fix
The Fix is to change EarlyBinder.bindSet to use BooleanSerializer to match FlinkSetState

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
