### PR TITLE
Add first-class DLQ API: DlqSink, FailedRecord, ParDoWit…

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DlqSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DlqSink.java
@@ -1,0 +1,36 @@
+package org.apache.beam.sdk.transforms;
+
+import java.io.Serializable;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+/**
+ * A sink for failed elements in a {@link ParDoWithDlq} transform.
+ *
+ * <p>Implementations are responsible for durably storing {@link FailedRecord}s so they can be
+ * inspected or replayed later. The Flink runner calls {@link #setup} once when the operator opens,
+ * {@link #write} for every failed element, and {@link #teardown} when the operator closes.
+ *
+ * <p><b>Contract:</b> {@link #write} must never throw. Any write failure should be caught
+ * internally and logged — the element is then silently dropped from the DLQ path rather than
+ * crashing the pipeline.
+ *
+ * @param <T> the input element type whose failures are being captured
+ */
+public interface DlqSink<T> extends Serializable {
+
+  /**
+   * Called once when the Flink operator opens. Use this to initialise connections or producers.
+   */
+  void setup(PipelineOptions options);
+
+  /**
+   * Writes a failed record to the DLQ. This method must never throw — implementations must catch
+   * and suppress all exceptions internally (best-effort semantics).
+   */
+  void write(FailedRecord<T> record);
+
+  /**
+   * Called once when the Flink operator closes. Use this to flush and close connections.
+   */
+  void teardown();
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/FailedRecord.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/FailedRecord.java
@@ -1,0 +1,74 @@
+package org.apache.beam.sdk.transforms;
+
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Throwables;
+import java.io.Serializable;
+import org.joda.time.Instant;
+
+/**
+ * Wraps a record that failed processing, carrying the original input alongside error context.
+ *
+ * <p>Used as the failure type in {@link ParDoWithDlq} when an element's {@code @ProcessElement}
+ * handler throws an exception.
+ *
+ * @param <T> the input element type
+ */
+public final class FailedRecord<T> implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final T input;
+  private final String errorType;
+  private final String stackTrace;
+  private final Instant failedAt;
+
+  private FailedRecord(T input, String errorType, String stackTrace, Instant failedAt) {
+    this.input = input;
+    this.errorType = errorType;
+    this.stackTrace = stackTrace;
+    this.failedAt = failedAt;
+  }
+
+  /**
+   * Creates a {@link FailedRecord} from the original input, the thrown exception, and the element's
+   * event-time timestamp.
+   *
+   * @param input       the original input element that caused the failure
+   * @param throwable   the exception that was thrown
+   * @param failedAt    the event-time timestamp of the element (not wall-clock time)
+   */
+  public static <T> FailedRecord<T> of(T input, Throwable throwable, Instant failedAt) {
+    return new FailedRecord<>(
+        input,
+        throwable.getClass().getName(),
+        Throwables.getStackTraceAsString(throwable),
+        failedAt);
+  }
+
+  /** The original input element that caused the failure. */
+  public T input() {
+    return input;
+  }
+
+  /** Fully-qualified class name of the exception (e.g. {@code java.lang.IllegalArgumentException}). */
+  public String errorType() {
+    return errorType;
+  }
+
+  /** Full stack trace string, including the exception message and cause chain. */
+  public String stackTrace() {
+    return stackTrace;
+  }
+
+  /**
+   * The event-time timestamp of the failed element, taken from the element's watermark position.
+   * This is NOT wall-clock time.
+   */
+  public Instant failedAt() {
+    return failedAt;
+  }
+
+  @Override
+  public String toString() {
+    return "FailedRecord{errorType=" + errorType + ", failedAt=" + failedAt + "}";
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -788,21 +788,40 @@ public class ParDo {
     }
 
     /**
-     * Returns a {@link ParDoWithDlq} that routes elements whose {@code @ProcessElement} throws to
-     * the given {@link DlqSink} instead of crashing the pipeline.
+     * Returns a transform that routes elements whose {@code @ProcessElement} throws to the given
+     * {@link DlqSink} instead of crashing the pipeline.
      *
      * <p>The returned transform produces a {@link PCollection} of successfully processed elements
      * only. Failed elements are written to the sink by the Flink runner — no side output or
      * {@link org.apache.beam.sdk.values.TupleTag} is visible to the caller.
      *
-     * <p>Use {@link ParDoWithDlq#withDlqFilter} to restrict which exception types are routed to
-     * the DLQ; non-matching exceptions re-throw and crash the pipeline.
+     * <p>To restrict which exception types are routed to the DLQ, use
+     * {@link #withDlq(DlqSink, SerializableFunction)}; non-matching exceptions re-throw and crash
+     * the pipeline.
      *
      * <p>Only supported in the Flink runner.
      */
-    public ParDoWithDlq<InputT, OutputT> withDlq(DlqSink<InputT> dlqSink) {
+    public PTransform<PCollection<? extends InputT>, PCollection<OutputT>> withDlq(
+        DlqSink<InputT> dlqSink) {
       checkArgument(dlqSink != null, "dlqSink must not be null");
       return new ParDoWithDlq<>(fn, dlqSink, null);
+    }
+
+    /**
+     * Returns a transform that routes elements whose {@code @ProcessElement} throws to the given
+     * {@link DlqSink}, filtered by the given predicate.
+     *
+     * <p>Only exceptions for which {@code dlqFilter} returns {@code true} are routed to the DLQ;
+     * others re-throw and crash the pipeline.
+     *
+     * <p>Only supported in the Flink runner.
+     */
+    public PTransform<PCollection<? extends InputT>, PCollection<OutputT>> withDlq(
+        DlqSink<InputT> dlqSink,
+        SerializableFunction<Throwable, Boolean> dlqFilter) {
+      checkArgument(dlqSink != null, "dlqSink must not be null");
+      checkArgument(dlqFilter != null, "dlqFilter must not be null");
+      return new ParDoWithDlq<>(fn, dlqSink, dlqFilter);
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -787,6 +787,24 @@ public class ParDo {
       return new MultiOutput<>(fn, sideInputs, mainOutputTag, additionalOutputTags, fnDisplayData);
     }
 
+    /**
+     * Returns a {@link ParDoWithDlq} that routes elements whose {@code @ProcessElement} throws to
+     * the given {@link DlqSink} instead of crashing the pipeline.
+     *
+     * <p>The returned transform produces a {@link PCollection} of successfully processed elements
+     * only. Failed elements are written to the sink by the Flink runner — no side output or
+     * {@link org.apache.beam.sdk.values.TupleTag} is visible to the caller.
+     *
+     * <p>Use {@link ParDoWithDlq#withDlqFilter} to restrict which exception types are routed to
+     * the DLQ; non-matching exceptions re-throw and crash the pipeline.
+     *
+     * <p>Only supported in the Flink runner.
+     */
+    public ParDoWithDlq<InputT, OutputT> withDlq(DlqSink<InputT> dlqSink) {
+      checkArgument(dlqSink != null, "dlqSink must not be null");
+      return new ParDoWithDlq<>(fn, dlqSink, null);
+    }
+
     @Override
     public PCollection<OutputT> expand(PCollection<? extends InputT> input) {
       SchemaRegistry schemaRegistry = input.getPipeline().getSchemaRegistry();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlq.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlq.java
@@ -1,0 +1,101 @@
+package org.apache.beam.sdk.transforms;
+
+import java.util.List;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.values.PCollection;
+
+/**
+ * A variant of {@link ParDo} that routes elements whose {@code @ProcessElement} handler throws to
+ * a {@link DlqSink} instead of crashing the pipeline.
+ *
+ * <p>Created via {@link ParDo.SingleOutput#withDlq(DlqSink)}:
+ *
+ * <pre>{@code
+ * PCollection<Output> results = input.apply(
+ *     ParDo.of(new MyFn())
+ *          .withDlq(myDlqSink)
+ *          .withDlqFilter(e -> e instanceof MyBusinessException));
+ * }</pre>
+ *
+ * <p>The returned {@link PCollection} contains only successfully processed elements. Failed
+ * elements are written to the {@link DlqSink} by the runner — no side output or tuple tag is
+ * visible to the caller.
+ *
+ * <p>Currently only supported in the Flink runner.
+ *
+ * @param <InputT>  the input element type
+ * @param <OutputT> the output element type (success path only)
+ */
+public class ParDoWithDlq<InputT, OutputT>
+    extends PTransform<PCollection<? extends InputT>, PCollection<OutputT>> {
+
+  /** URN used by the Flink runner to identify and translate this transform. */
+  public static final String URN = "beam:transform:li:pardo_with_dlq:v1";
+
+  private static final List<String> ALLOWED_RUNNERS =
+      ImmutableList.of(
+          "org.apache.beam.runners.flink.FlinkRunner",
+          "com.linkedin.beam.runners.LineageFlinkRunner");
+
+  private final DoFn<InputT, OutputT> fn;
+  private final DlqSink<InputT> dlqSink;
+  @Nullable private final SerializableFunction<Throwable, Boolean> dlqFilter;
+
+  ParDoWithDlq(
+      DoFn<InputT, OutputT> fn,
+      DlqSink<InputT> dlqSink,
+      @Nullable SerializableFunction<Throwable, Boolean> dlqFilter) {
+    this.fn = fn;
+    this.dlqSink = dlqSink;
+    this.dlqFilter = dlqFilter;
+  }
+
+  /**
+   * Returns a new {@link ParDoWithDlq} that additionally applies the given filter predicate.
+   * Only exceptions for which the predicate returns {@code true} are routed to the DLQ; others
+   * re-throw and crash the pipeline.
+   */
+  public ParDoWithDlq<InputT, OutputT> withDlqFilter(
+      SerializableFunction<Throwable, Boolean> dlqFilter) {
+    Preconditions.checkArgument(dlqFilter != null, "dlqFilter must not be null");
+    return new ParDoWithDlq<>(fn, dlqSink, dlqFilter);
+  }
+
+  public DoFn<InputT, OutputT> getFn() {
+    return fn;
+  }
+
+  public DlqSink<InputT> getDlqSink() {
+    return dlqSink;
+  }
+
+  @Nullable
+  public SerializableFunction<Throwable, Boolean> getDlqFilter() {
+    return dlqFilter;
+  }
+
+  @Override
+  public void validate(@Nullable PipelineOptions options) {
+    if (options == null) {
+      return;
+    }
+    Preconditions.checkState(
+        ALLOWED_RUNNERS.contains(options.getRunner().getName()),
+        "ParDoWithDlq is not supported in runner: %s",
+        options.getRunner().getName());
+  }
+
+  /**
+   * Creates a single primitive output {@link PCollection} for the success path. The DLQ path is
+   * handled entirely within the Flink runner via the registered {@link DlqSink} — no side output
+   * is added to the Beam pipeline graph.
+   */
+  @Override
+  public PCollection<OutputT> expand(PCollection<? extends InputT> input) {
+    return PCollection.createPrimitiveOutputInternal(
+        input.getPipeline(), input.getWindowingStrategy(), input.isBounded(), null);
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlq.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlq.java
@@ -8,32 +8,18 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.values.PCollection;
 
 /**
- * A variant of {@link ParDo} that routes elements whose {@code @ProcessElement} handler throws to
- * a {@link DlqSink} instead of crashing the pipeline.
+ * Package-private implementation of the DLQ-enabled ParDo transform.
  *
- * <p>Created via {@link ParDo.SingleOutput#withDlq(DlqSink)}:
- *
- * <pre>{@code
- * PCollection<Output> results = input.apply(
- *     ParDo.of(new MyFn())
- *          .withDlq(myDlqSink)
- *          .withDlqFilter(e -> e instanceof MyBusinessException));
- * }</pre>
- *
- * <p>The returned {@link PCollection} contains only successfully processed elements. Failed
- * elements are written to the {@link DlqSink} by the runner — no side output or tuple tag is
- * visible to the caller.
- *
- * <p>Currently only supported in the Flink runner.
+ * <p>Instances are created exclusively via {@link ParDo.SingleOutput#withDlq(DlqSink)} or
+ * {@link ParDo.SingleOutput#withDlq(DlqSink, SerializableFunction)}. Callers outside this package
+ * interact with this transform through the {@link ParDoWithDlqSpec} interface.
  *
  * @param <InputT>  the input element type
  * @param <OutputT> the output element type (success path only)
  */
-public class ParDoWithDlq<InputT, OutputT>
-    extends PTransform<PCollection<? extends InputT>, PCollection<OutputT>> {
-
-  /** URN used by the Flink runner to identify and translate this transform. */
-  public static final String URN = "beam:transform:li:pardo_with_dlq:v1";
+class ParDoWithDlq<InputT, OutputT>
+    extends PTransform<PCollection<? extends InputT>, PCollection<OutputT>>
+    implements ParDoWithDlqSpec<InputT, OutputT> {
 
   private static final List<String> ALLOWED_RUNNERS =
       ImmutableList.of(
@@ -53,25 +39,17 @@ public class ParDoWithDlq<InputT, OutputT>
     this.dlqFilter = dlqFilter;
   }
 
-  /**
-   * Returns a new {@link ParDoWithDlq} that additionally applies the given filter predicate.
-   * Only exceptions for which the predicate returns {@code true} are routed to the DLQ; others
-   * re-throw and crash the pipeline.
-   */
-  public ParDoWithDlq<InputT, OutputT> withDlqFilter(
-      SerializableFunction<Throwable, Boolean> dlqFilter) {
-    Preconditions.checkArgument(dlqFilter != null, "dlqFilter must not be null");
-    return new ParDoWithDlq<>(fn, dlqSink, dlqFilter);
-  }
-
+  @Override
   public DoFn<InputT, OutputT> getFn() {
     return fn;
   }
 
+  @Override
   public DlqSink<InputT> getDlqSink() {
     return dlqSink;
   }
 
+  @Override
   @Nullable
   public SerializableFunction<Throwable, Boolean> getDlqFilter() {
     return dlqFilter;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlqSpec.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlqSpec.java
@@ -1,0 +1,47 @@
+package org.apache.beam.sdk.transforms;
+
+import javax.annotation.Nullable;
+
+/**
+ * Public accessor interface for the package-private {@link ParDoWithDlq} transform.
+ *
+ * <p>This interface allows the Flink runner (which lives in a different package) to
+ * inspect transform properties — {@link #getFn()}, {@link #getDlqSink()},
+ * {@link #getDlqFilter()} — and reference the {@link #URN} constant, without
+ * needing to import the package-private implementation class.
+ *
+ * <p>Callers outside {@code org.apache.beam.sdk.transforms} should interact with this
+ * transform only through {@link ParDo.SingleOutput#withDlq(DlqSink)} and
+ * {@link ParDo.SingleOutput#withDlq(DlqSink, SerializableFunction)}.
+ *
+ * @param <InputT>  the input element type
+ * @param <OutputT> the output element type (success path only)
+ */
+public interface ParDoWithDlqSpec<InputT, OutputT> {
+
+  /** URN used by the Flink runner to identify and translate this transform. */
+  String URN = "beam:transform:li:pardo_with_dlq:v1";
+
+  /** Returns the wrapped {@link DoFn}. */
+  DoFn<InputT, OutputT> getFn();
+
+  /** Returns the {@link DlqSink} that receives failed elements. */
+  DlqSink<InputT> getDlqSink();
+
+  /**
+   * Returns the optional filter predicate, or {@code null} if all exceptions are routed to
+   * the DLQ.
+   */
+  @Nullable
+  SerializableFunction<Throwable, Boolean> getDlqFilter();
+
+  /**
+   * Returns the implementation {@link PTransform} class for use in payload translator
+   * registration. Accessible here because this interface is in the same package as the
+   * package-private {@link ParDoWithDlq}.
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  static Class<? extends PTransform<?, ?>> implementationClass() {
+    return (Class<? extends PTransform<?, ?>>) (Class) ParDoWithDlq.class;
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoWithDlqTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoWithDlqTest.java
@@ -68,55 +68,59 @@ public class ParDoWithDlqTest implements Serializable {
   @Test
   public void testWithDlqReturnedFromParDoOf() {
     CapturingDlqSink<Integer> sink = new CapturingDlqSink<>();
-    ParDoWithDlq<Integer, Integer> transform = ParDo.of(new PassThroughFn()).withDlq(sink);
-    assertNotNull(transform);
+    assertNotNull(ParDo.of(new PassThroughFn()).withDlq(sink));
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testGetFnReturnsSameFn() {
     PassThroughFn fn = new PassThroughFn();
-    ParDoWithDlq<Integer, Integer> transform =
-        ParDo.of(fn).withDlq(new CapturingDlqSink<>());
+    ParDoWithDlqSpec<Integer, Integer> transform =
+        (ParDoWithDlqSpec<Integer, Integer>) ParDo.of(fn).withDlq(new CapturingDlqSink<>());
     assertSame(fn, transform.getFn());
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testGetDlqSinkReturnsSameSink() {
     CapturingDlqSink<Integer> sink = new CapturingDlqSink<>();
-    ParDoWithDlq<Integer, Integer> transform = ParDo.of(new PassThroughFn()).withDlq(sink);
+    ParDoWithDlqSpec<Integer, Integer> transform =
+        (ParDoWithDlqSpec<Integer, Integer>) ParDo.of(new PassThroughFn()).withDlq(sink);
     assertSame(sink, transform.getDlqSink());
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testDlqFilterIsNullByDefault() {
-    ParDoWithDlq<Integer, Integer> transform =
-        ParDo.of(new PassThroughFn()).withDlq(new CapturingDlqSink<>());
+    ParDoWithDlqSpec<Integer, Integer> transform =
+        (ParDoWithDlqSpec<Integer, Integer>) ParDo.of(new PassThroughFn()).withDlq(new CapturingDlqSink<>());
     assertNull(transform.getDlqFilter());
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testWithDlqFilterSetsFilter() {
     SerializableFunction<Throwable, Boolean> filter = t -> t instanceof IllegalArgumentException;
-    ParDoWithDlq<Integer, Integer> transform =
-        ParDo.of(new PassThroughFn())
-            .withDlq(new CapturingDlqSink<>())
-            .withDlqFilter(filter);
+    ParDoWithDlqSpec<Integer, Integer> transform =
+        (ParDoWithDlqSpec<Integer, Integer>) ParDo.of(new PassThroughFn())
+            .withDlq(new CapturingDlqSink<>(), filter);
     assertSame(filter, transform.getDlqFilter());
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testWithDlqFilterPreservesFnAndSink() {
     PassThroughFn fn = new PassThroughFn();
     CapturingDlqSink<Integer> sink = new CapturingDlqSink<>();
-    ParDoWithDlq<Integer, Integer> transform =
-        ParDo.of(fn).withDlq(sink).withDlqFilter(t -> true);
+    ParDoWithDlqSpec<Integer, Integer> transform =
+        (ParDoWithDlqSpec<Integer, Integer>) ParDo.of(fn).withDlq(sink, t -> true);
     assertSame(fn, transform.getFn());
     assertSame(sink, transform.getDlqSink());
   }
 
   @Test
   public void testUrnConstant() {
-    assertEquals("beam:transform:li:pardo_with_dlq:v1", ParDoWithDlq.URN);
+    assertEquals("beam:transform:li:pardo_with_dlq:v1", ParDoWithDlqSpec.URN);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -126,7 +130,7 @@ public class ParDoWithDlqTest implements Serializable {
 
   @Test(expected = IllegalArgumentException.class)
   public void testWithDlqFilterRejectsNullFilter() {
-    ParDo.of(new PassThroughFn()).withDlq(new CapturingDlqSink<>()).withDlqFilter(null);
+    ParDo.of(new PassThroughFn()).withDlq(new CapturingDlqSink<>(), null);
   }
 
   // ---------------------------------------------------------------------------

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoWithDlqTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoWithDlqTest.java
@@ -1,0 +1,188 @@
+package org.apache.beam.sdk.transforms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.io.Serializable;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.joda.time.Instant;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link ParDoWithDlq} and related types.
+ *
+ * <p>These tests cover API construction, field accessors, and the {@link FailedRecord} /
+ * {@link DlqSink} contracts. Pipeline execution tests (which require the Flink runner) live in
+ * {@code beam-runner/runtime-flink}.
+ */
+@RunWith(JUnit4.class)
+public class ParDoWithDlqTest implements Serializable {
+
+  // ---------------------------------------------------------------------------
+  // Test helpers
+  // ---------------------------------------------------------------------------
+
+  static class PassThroughFn extends DoFn<Integer, Integer> {
+    @ProcessElement
+    public void processElement(@Element Integer input, OutputReceiver<Integer> out) {
+      out.output(input);
+    }
+  }
+
+  static class ThrowForEvenFn extends DoFn<Integer, Integer> {
+    @ProcessElement
+    public void processElement(@Element Integer input, OutputReceiver<Integer> out) {
+      if (input % 2 == 0) {
+        throw new IllegalArgumentException("Even input rejected: " + input);
+      }
+      out.output(input);
+    }
+  }
+
+  /** A no-op {@link DlqSink} that records the last written record for assertions. */
+  static class CapturingDlqSink<T> implements DlqSink<T> {
+    FailedRecord<T> lastRecord;
+    int writeCount = 0;
+
+    @Override
+    public void setup(PipelineOptions options) {}
+
+    @Override
+    public void write(FailedRecord<T> record) {
+      lastRecord = record;
+      writeCount++;
+    }
+
+    @Override
+    public void teardown() {}
+  }
+
+  // ---------------------------------------------------------------------------
+  // ParDoWithDlq construction
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testWithDlqReturnedFromParDoOf() {
+    CapturingDlqSink<Integer> sink = new CapturingDlqSink<>();
+    ParDoWithDlq<Integer, Integer> transform = ParDo.of(new PassThroughFn()).withDlq(sink);
+    assertNotNull(transform);
+  }
+
+  @Test
+  public void testGetFnReturnsSameFn() {
+    PassThroughFn fn = new PassThroughFn();
+    ParDoWithDlq<Integer, Integer> transform =
+        ParDo.of(fn).withDlq(new CapturingDlqSink<>());
+    assertSame(fn, transform.getFn());
+  }
+
+  @Test
+  public void testGetDlqSinkReturnsSameSink() {
+    CapturingDlqSink<Integer> sink = new CapturingDlqSink<>();
+    ParDoWithDlq<Integer, Integer> transform = ParDo.of(new PassThroughFn()).withDlq(sink);
+    assertSame(sink, transform.getDlqSink());
+  }
+
+  @Test
+  public void testDlqFilterIsNullByDefault() {
+    ParDoWithDlq<Integer, Integer> transform =
+        ParDo.of(new PassThroughFn()).withDlq(new CapturingDlqSink<>());
+    assertNull(transform.getDlqFilter());
+  }
+
+  @Test
+  public void testWithDlqFilterSetsFilter() {
+    SerializableFunction<Throwable, Boolean> filter = t -> t instanceof IllegalArgumentException;
+    ParDoWithDlq<Integer, Integer> transform =
+        ParDo.of(new PassThroughFn())
+            .withDlq(new CapturingDlqSink<>())
+            .withDlqFilter(filter);
+    assertSame(filter, transform.getDlqFilter());
+  }
+
+  @Test
+  public void testWithDlqFilterPreservesFnAndSink() {
+    PassThroughFn fn = new PassThroughFn();
+    CapturingDlqSink<Integer> sink = new CapturingDlqSink<>();
+    ParDoWithDlq<Integer, Integer> transform =
+        ParDo.of(fn).withDlq(sink).withDlqFilter(t -> true);
+    assertSame(fn, transform.getFn());
+    assertSame(sink, transform.getDlqSink());
+  }
+
+  @Test
+  public void testUrnConstant() {
+    assertEquals("beam:transform:li:pardo_with_dlq:v1", ParDoWithDlq.URN);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithDlqRejectsNullSink() {
+    ParDo.of(new PassThroughFn()).withDlq(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithDlqFilterRejectsNullFilter() {
+    ParDo.of(new PassThroughFn()).withDlq(new CapturingDlqSink<>()).withDlqFilter(null);
+  }
+
+  // ---------------------------------------------------------------------------
+  // FailedRecord
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testFailedRecordFields() {
+    Instant ts = Instant.ofEpochMilli(12345L);
+    IllegalArgumentException ex = new IllegalArgumentException("bad input");
+    FailedRecord<Integer> record = FailedRecord.of(42, ex, ts);
+
+    assertEquals(Integer.valueOf(42), record.input());
+    assertEquals(IllegalArgumentException.class.getName(), record.errorType());
+    assertNotNull(record.stackTrace());
+    org.junit.Assert.assertTrue(record.stackTrace().contains("bad input"));
+    assertEquals(ts, record.failedAt());
+  }
+
+  @Test
+  public void testFailedRecordCauseChainIsIncluded() {
+    RuntimeException cause = new RuntimeException("root cause");
+    RuntimeException wrapper = new RuntimeException("wrapper", cause);
+    FailedRecord<String> record = FailedRecord.of("input", wrapper, Instant.now());
+    org.junit.Assert.assertTrue(
+        "Stack trace should include the cause", record.stackTrace().contains("root cause"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // DlqSink contract: write must not throw
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testDlqSinkWriteDoesNotThrow() {
+    DlqSink<Integer> throwingSink =
+        new DlqSink<Integer>() {
+          @Override
+          public void setup(PipelineOptions options) {}
+
+          @Override
+          public void write(FailedRecord<Integer> record) {
+            // A well-behaved sink catches its own errors — simulate a failure being swallowed
+            try {
+              throw new RuntimeException("simulated write failure");
+            } catch (RuntimeException ignored) {
+              // best-effort: do not propagate
+            }
+          }
+
+          @Override
+          public void teardown() {}
+        };
+
+    // Calling write should not throw even if the sink itself encounters an error
+    FailedRecord<Integer> record =
+        FailedRecord.of(1, new IllegalStateException("test"), Instant.now());
+    throwingSink.write(record); // must not throw
+  }
+}


### PR DESCRIPTION
…hDlq, ParDo.withDlq()

Introduces the Li-specific DLQ API to the Beam Java SDK so that the Flink runner can route failed elements to a dead-letter topic without crashing the pipeline and without requiring per-DoFn TupleTag boilerplate.

New classes
-----------
* `DlqSink<T>` — serializable interface (`setup`, `write`, `teardown`) that the Flink runner calls around DoFn execution; implementations (e.g. XinfraDlqSink) live in beam-runner and carry no fork-level deps.
* `FailedRecord<T>` — value type carrying the failed input element, exception class name, full stack trace, and event timestamp.
* `ParDoWithDlq<InputT,OutputT>` — PTransform with URN `beam:transform:li:pardo_with_dlq:v1` recognised by the Flink runner's custom translator. Produces a single `PCollection<OutputT>` (success path only); the DLQ path is handled entirely inside the runner.

API entry point
---------------
`ParDo.SingleOutput#withDlq(DlqSink)` returns a `ParDoWithDlq` — the only call-site change needed is replacing `ParDo.of(fn)` with `ParDo.of(fn).withDlq(sink)`. `.withDlqFilter(predicate)` optionally restricts which exception types are routed to the DLQ.

Validation
----------
* `ParDoWithDlq.validate()` rejects unsupported runners at pipeline construction time.
* 12 unit tests in `ParDoWithDlqTest` covering construction, filter chaining, and runner validation.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
