### PR TITLE
Add skipReshuffleForParDo option to FlinkPipelineOptions

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.53'
+    project.version = '2.45.54'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.53
-sdk_version=2.45.53
+version=2.45.54
+sdk_version=2.45.54
 
 javaVersion=1.8
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -305,6 +305,18 @@ public interface FlinkPipelineOptions
 
   void setFlinkConfDir(String confDir);
 
+  @Description(
+      "When true, stateful ParDo operators use DataStreamUtils.reinterpretAsKeyedStream() instead"
+          + " of DataStream.keyBy(), eliminating the HASH network exchange before stateful DoFns."
+          + " Requires that every input PCollection is already correctly key-partitioned by the"
+          + " Flink-compatible hash function (Kafka producer must use a MurmurHash3-aligned"
+          + " partitioner matching Flink's KvToByteBufferKeySelector). Incorrect alignment causes"
+          + " silent state corruption.")
+  @Default.Boolean(false)
+  Boolean getSkipReshuffleForParDo();
+
+  void setSkipReshuffleForParDo(Boolean value);
+
   static FlinkPipelineOptions defaults() {
     return PipelineOptionsFactory.as(FlinkPipelineOptions.class);
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -613,9 +613,14 @@ class FlinkStreamingTransformTranslators {
             producer != null
                 ? PTransformTranslation.urnForTransformOrNull(context.getProducer(input))
                 : null;
-        // We can skip reshuffle in case previous transform was CPK or GBK
+        // We can skip reshuffle in case previous transform was CPK or GBK,
+        // or if the caller asserts input is already correctly key-partitioned.
         if (PTransformTranslation.COMBINE_PER_KEY_TRANSFORM_URN.equals(previousUrn)
-            || PTransformTranslation.GROUP_BY_KEY_TRANSFORM_URN.equals(previousUrn)) {
+            || PTransformTranslation.GROUP_BY_KEY_TRANSFORM_URN.equals(previousUrn)
+            || context
+                .getPipelineOptions()
+                .as(FlinkPipelineOptions.class)
+                .getSkipReshuffleForParDo()) {
           inputDataStream = DataStreamUtils.reinterpretAsKeyedStream(inputDataStream, keySelector);
         } else {
           inputDataStream = inputDataStream.keyBy(keySelector);


### PR DESCRIPTION
## Summary                                                                                                                                      
                                                                         
  - Adds `skipReshuffleForParDo` boolean option (default `false`) to `FlinkPipelineOptions`                                                       
  - When `true`, extends the existing CPK/GBK reshuffle-skip path in `FlinkStreamingTransformTranslators` to also apply for all stateful ParDo
  operators — using `DataStreamUtils.reinterpretAsKeyedStream()` instead of `.keyBy()`, eliminating the HASH network exchange                     
  - Bumps version `2.45.53` → `2.45.54`                                                                                                           
                                                                                                                                                  
  ## Motivation                                                        
  CTC Flink jobs have stateful DoFns (e.g. `CtcPipelineDoFn`). Under hot-key load the HASH exchange before each stateful ParDo fills a shared
  network buffer and cascades backpressure to all source tasks. Eliminating the HASH makes backpressure local to the affected task.               
                                                                                                                                   
  ## Design                         
                                                                       
  One-line condition extension in the existing reshuffle decision in `FlinkStreamingTransformTranslators` — no new code paths, off by default.
                                                                                                                                              
  ## Safety
           
  Callers must guarantee every input PCollection is already correctly key-partitioned via Flink's `KvToByteBufferKeySelector` hash. A runtime
  validator (`FlinkKeyGroupValidator`) is being added in the beam-runner layer to catch drift.                                                    
                                                                                              
  ## Test plan                      
  - [ ] Existing `FlinkStreamingTransformTranslatorsTest` passes (no regression)
  - [ ] Downstream beam-runner `LiFlinkParDoTranslatorTest`: `false` → 2 HASH edges; `true` → 1 HASH edge
  - [ ] CTC EI: Flink UI shows `FORWARD` before `CtcPipelineDoFn`; `flink_key_group_mismatches == 0`     