### PR TITLE
Relocate org.apache.datasketches in beam-sdks-java-harness

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.54'
+    project.version = '2.45.55'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.54
-sdk_version=2.45.54
+version=2.45.55
+sdk_version=2.45.55
 
 javaVersion=1.8
 

--- a/sdks/java/harness/build.gradle
+++ b/sdks/java/harness/build.gradle
@@ -67,6 +67,7 @@ applyJavaNature(
         exclude(dependency(it.getModuleGroup() + ":" + it.getModuleName() + ":.*"))
       }
     }
+    relocate 'org.apache.datasketches', getJavaRelocatedPath('org.apache.datasketches')
   },
 )
 


### PR DESCRIPTION
## Problem

 `beam-sdks-java-harness` bundled ~70 unrelocated `org.apache.datasketches.memory.*` classes frozen at v2.0.0 with no shade relocation. These conflict with `datasketches-memory:3.0.2` pulled in
  transitively via `datasketches-java:3.0.0` in consumer MPs, causing linkage checker "missing method" errors.

  Root cause: `BaseWritableMemoryImpl` in v2.0.0 extends `BaseStateImpl` (no `AutoCloseable`), but in v3.0.2 it extends `ResourceImpl implements Resource` (adds `close()`). Both versions share the same
  FQCNs, causing binary incompatibility.


## Fix

 Add a shade relocation rule in `sdks/java/harness/build.gradle` to relocate `org.apache.datasketches` to `org.apache.beam.repackaged.harness.org.apache.datasketches`, following the same pattern already
  used in `sdks/java/core` for `commons-compress`, `commons-lang3`, and `antlr`.

## Verification

  Before fix — ~70 unrelocated classes visible:
  `jar tf beam-sdks-java-harness-2.45.54-SNAPSHOT.jar | grep '^org/apache/datasketches/memory/'`
  returns ~70 classes


  After fix — no unrelocated classes, all relocated to shaded path:
  `jar tf beam-sdks-java-harness-2.45.55-SNAPSHOT.jar | grep '^org/apache/datasketches/memory/'`
  returns nothing

  `jar tf beam-sdks-java-harness-2.45.55-SNAPSHOT.jar | grep 'datasketches'`
  returns org/apache/beam/repackaged/harness/org/apache/datasketches/...


## Changes
  - `sdks/java/harness/build.gradle`: add relocation rule for `org.apache.datasketches`
  - `buildSrc/.../BeamModulePlugin.groovy`: bump version to `2.45.55`
  - `gradle.properties`: bump version to `2.45.55`

