### PR TITLE
Exclude build-only dependencies from beam-sdks-java-harness jar

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.55'
+    project.version = '2.45.56'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.55
-sdk_version=2.45.55
+version=2.45.56
+sdk_version=2.45.56
 
 javaVersion=1.8
 

--- a/sdks/java/harness/build.gradle
+++ b/sdks/java/harness/build.gradle
@@ -66,6 +66,11 @@ applyJavaNature(
           .getLenientConfiguration().getAllModuleDependencies().each {
         exclude(dependency(it.getModuleGroup() + ":" + it.getModuleName() + ":.*"))
       }
+      // Exclude build-only dependencies that should not be bundled in the jar
+      exclude(dependency('junit:junit:.*'))
+      exclude(dependency('org.hamcrest:.*:.*'))
+      exclude(dependency('org.checkerframework:.*:.*'))
+      exclude(dependency('io.github.classgraph:classgraph:.*'))
     }
     relocate 'org.apache.datasketches', getJavaRelocatedPath('org.apache.datasketches')
   },


### PR DESCRIPTION
## Problem

  `beam-sdks-java-harness` was bundling build/compile-time only dependencies into its uber jar with no shade relocation, leaking them onto consumer MP classpaths:

  - `junit` / `junit.framework` / `junit.runner` — test framework (6+17+3+2 classes)
  - `org.hamcrest` — test assertion library (109 classes)
  - `org.checkerframework` — compile-time annotation only, no runtime behavior (358 classes)
  - `io.github.classgraph` / `nonapi.io` — not used in harness main source (122+120 classes)

  None of these are used in `sdks/java/harness/src/main/java/` at runtime (verified via grep). `org.checkerframework.@Nullable` is used as a compile-time annotation only and is not needed at runtime.

  ## Fix

  Explicitly exclude these build-only dependencies from the `shadowClosure` dependencies block in `sdks/java/harness/build.gradle` so they are not bundled into the fat jar.

  ## Verification

  Before fix:
  `jar tf beam-sdks-java-harness-2.45.55-SNAPSHOT.jar | grep -E '^(junit|org/hamcrest|org/checkerframework|io/github/classgraph|nonapi/io)/'`
  returns 700+ classes


  After fix:
  `jar tf beam-sdks-java-harness-2.45.56-SNAPSHOT.jar | grep -E '^(junit|org/hamcrest|org/checkerframework|io/github/classgraph|nonapi/io)/'`
  returns nothing


  ## Changes
  - `sdks/java/harness/build.gradle`: exclude `junit`, `hamcrest`, `checkerframework`, `classgraph` from shadow jar bundling
  - `buildSrc/.../BeamModulePlugin.groovy`: bump version to `2.45.56`
  - `gradle.properties`: bump version to `2.45.56`
