### PR TITLE
ParDoWithDlq: propagate output coder + add ParDo.MultiOutput.withDlq  

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -398,7 +398,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
     // Automatically use the official release version if we are performing a release
     // otherwise append '-SNAPSHOT'
-    project.version = '2.45.56'
+    project.version = '2.45.57'
     if (isLinkedin(project)) {
       project.ext.mavenGroupId = 'com.linkedin.beam'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ signing.gnupg.useLegacyGpg=true
 # buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy.
 # To build a custom Beam version make sure you change it in both places, see
 # https://github.com/apache/beam/issues/21302.
-version=2.45.56
-sdk_version=2.45.56
+version=2.45.57
+sdk_version=2.45.57
 
 javaVersion=1.8
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -975,6 +975,46 @@ public class ParDo {
       return withSideInputs(Collections.singletonMap(tagId, pCollectionView));
     }
 
+    /**
+     * Returns a transform that routes elements whose {@code @ProcessElement} throws to the given
+     * {@link DlqSink}.
+     *
+     * <p>Success-path elements continue to flow to the main and additional output tags as
+     * usual; the returned transform's output {@link PCollectionTuple} has the same shape as
+     * this {@link MultiOutput}'s. Failed elements are written to the sink by the Flink runner —
+     * no extra side output or {@link TupleTag} is added to the user-facing tuple.
+     *
+     * <p>To restrict which exception types are routed to the DLQ, use
+     * {@link #withDlq(DlqSink, SerializableFunction)}; non-matching exceptions re-throw and
+     * crash the pipeline.
+     *
+     * <p>Only supported in the Flink runner.
+     */
+    public PTransform<PCollection<? extends InputT>, PCollectionTuple> withDlq(
+        DlqSink<InputT> dlqSink) {
+      checkArgument(dlqSink != null, "dlqSink must not be null");
+      return new ParDoWithDlqMultiOutput<>(
+          fn, mainOutputTag, additionalOutputTags, sideInputs, dlqSink, null);
+    }
+
+    /**
+     * Returns a transform that routes elements whose {@code @ProcessElement} throws to the given
+     * {@link DlqSink}, filtered by the given predicate.
+     *
+     * <p>Only exceptions for which {@code dlqFilter} returns {@code true} are routed to the DLQ;
+     * others re-throw and crash the pipeline.
+     *
+     * <p>Only supported in the Flink runner.
+     */
+    public PTransform<PCollection<? extends InputT>, PCollectionTuple> withDlq(
+        DlqSink<InputT> dlqSink,
+        SerializableFunction<Throwable, Boolean> dlqFilter) {
+      checkArgument(dlqSink != null, "dlqSink must not be null");
+      checkArgument(dlqFilter != null, "dlqFilter must not be null");
+      return new ParDoWithDlqMultiOutput<>(
+          fn, mainOutputTag, additionalOutputTags, sideInputs, dlqSink, dlqFilter);
+    }
+
     @Override
     public PCollectionTuple expand(PCollection<? extends InputT> input) {
       // SplittableDoFn should be forbidden on the runner-side.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlq.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlq.java
@@ -4,8 +4,13 @@ import java.util.List;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
+import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.schemas.NoSuchSchemaException;
+import org.apache.beam.sdk.schemas.SchemaRegistry;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * Package-private implementation of the DLQ-enabled ParDo transform.
@@ -70,10 +75,38 @@ class ParDoWithDlq<InputT, OutputT>
    * Creates a single primitive output {@link PCollection} for the success path. The DLQ path is
    * handled entirely within the Flink runner via the registered {@link DlqSink} — no side output
    * is added to the Beam pipeline graph.
+   *
+   * <p>Mirrors {@link ParDo.SingleOutput#expand}'s schema/coder inference so the wrapping does
+   * not erase output type info. Without this, callers that wrap an anonymous-class DoFn would
+   * see "Unable to return a default Coder" downstream because plain ParDo's coder inference is
+   * bypassed by the wrapping PTransform.
    */
   @Override
+  @SuppressWarnings("unchecked")
   public PCollection<OutputT> expand(PCollection<? extends InputT> input) {
-    return PCollection.createPrimitiveOutputInternal(
+    PCollection<OutputT> output = PCollection.createPrimitiveOutputInternal(
         input.getPipeline(), input.getWindowingStrategy(), input.isBounded(), null);
+    SchemaRegistry schemaRegistry = input.getPipeline().getSchemaRegistry();
+    CoderRegistry coderRegistry = input.getPipeline().getCoderRegistry();
+    TypeDescriptor<OutputT> outputTypeDescriptor = fn.getOutputTypeDescriptor();
+    try {
+      output.setSchema(
+          schemaRegistry.getSchema(outputTypeDescriptor),
+          outputTypeDescriptor,
+          schemaRegistry.getToRowFunction(outputTypeDescriptor),
+          schemaRegistry.getFromRowFunction(outputTypeDescriptor));
+    } catch (NoSuchSchemaException e) {
+      try {
+        output.setCoder(
+            coderRegistry.getCoder(
+                outputTypeDescriptor,
+                fn.getInputTypeDescriptor(),
+                ((PCollection<InputT>) input).getCoder()));
+      } catch (CannotProvideCoderException e2) {
+        // Ignore and leave coder unset — caller can still .setCoder explicitly. Matches
+        // ParDo.SingleOutput's behavior.
+      }
+    }
+    return output;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlqMultiOutput.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlqMultiOutput.java
@@ -30,6 +30,10 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
  *
  * @param <InputT> the input element type
  */
+@SuppressWarnings({
+  "nullness", // matches the suppression on ParDo (TODO: apache/beam#20497)
+  "rawtypes"
+})
 class ParDoWithDlqMultiOutput<InputT>
     extends PTransform<PCollection<? extends InputT>, PCollectionTuple>
     implements ParDoWithDlqMultiOutputSpec<InputT> {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlqMultiOutput.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlqMultiOutput.java
@@ -11,6 +11,8 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.PCollectionViews;
+import org.apache.beam.sdk.values.PValue;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
@@ -85,6 +87,22 @@ class ParDoWithDlqMultiOutput<InputT>
     return sideInputs;
   }
 
+  /**
+   * Declares the side-input views this transform consumes, mirroring {@link
+   * ParDo.MultiOutput#getAdditionalInputs}.
+   *
+   * <p>Because {@link #expand} only emits primitive outputs and never applies an inner {@code
+   * ParDo}, the side-input views are not referenced anywhere in the visible graph. This override is
+   * how the runner's topological traversal learns the transform consumes those views and must
+   * translate the view-producing subgraph first; without it a multi-output {@code .withDlq(...)}
+   * with side inputs risks the consuming operator being translated before its side-input stream
+   * exists.
+   */
+  @Override
+  public Map<TupleTag<?>, PValue> getAdditionalInputs() {
+    return PCollectionViews.toAdditionalInputs(sideInputs.values());
+  }
+
   @Override
   public DlqSink<InputT> getDlqSink() {
     return dlqSink;
@@ -139,6 +157,13 @@ class ParDoWithDlqMultiOutput<InputT>
         // ParDo.MultiOutput's expand behavior.
       }
     }
+    // Mirror the final step of ParDo.MultiOutput.expand: the fn is typically an anonymous subclass
+    // (e.g. new DoFn<Integer, String>(){...}) carrying a high-fidelity output TypeDescriptor.
+    // Setting it on the main output recovers coder inference for the common idiom of a raw main tag
+    // (new TupleTag<>()), where out.getTypeDescriptor() above is null and the per-tag getCoder()
+    // could not resolve a coder — without this the main output is left with no coder and downstream
+    // applies throw "Unable to return a default Coder", the exact failure this PR fixes.
+    ((PCollection) outputs.get(mainOutputTag)).setTypeDescriptor(fn.getOutputTypeDescriptor());
     return outputs;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlqMultiOutput.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlqMultiOutput.java
@@ -1,0 +1,140 @@
+package org.apache.beam.sdk.transforms;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderRegistry;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TupleTagList;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+
+/**
+ * Package-private implementation of the multi-output DLQ-enabled ParDo transform.
+ *
+ * <p>Multi-output counterpart to {@link ParDoWithDlq}. Instances are created exclusively via
+ * {@link ParDo.MultiOutput#withDlq(DlqSink)} or
+ * {@link ParDo.MultiOutput#withDlq(DlqSink, SerializableFunction)}. Callers outside this package
+ * interact with this transform through the {@link ParDoWithDlqMultiOutputSpec} interface.
+ *
+ * <p>The Beam pipeline graph still exposes the same {@link PCollectionTuple} the wrapped
+ * {@code ParDo.MultiOutput} would produce — the DLQ side output is handled entirely within the
+ * Flink runner via the registered {@link DlqSink} and is not visible in the user-facing tuple.
+ *
+ * @param <InputT> the input element type
+ */
+class ParDoWithDlqMultiOutput<InputT>
+    extends PTransform<PCollection<? extends InputT>, PCollectionTuple>
+    implements ParDoWithDlqMultiOutputSpec<InputT> {
+
+  private static final List<String> ALLOWED_RUNNERS =
+      ImmutableList.of(
+          "org.apache.beam.runners.flink.FlinkRunner",
+          "com.linkedin.beam.runners.LineageFlinkRunner");
+
+  private final DoFn<InputT, ?> fn;
+  private final TupleTag<?> mainOutputTag;
+  private final TupleTagList additionalOutputTags;
+  private final Map<String, PCollectionView<?>> sideInputs;
+  private final DlqSink<InputT> dlqSink;
+  @Nullable private final SerializableFunction<Throwable, Boolean> dlqFilter;
+
+  ParDoWithDlqMultiOutput(
+      DoFn<InputT, ?> fn,
+      TupleTag<?> mainOutputTag,
+      TupleTagList additionalOutputTags,
+      Map<String, PCollectionView<?>> sideInputs,
+      DlqSink<InputT> dlqSink,
+      @Nullable SerializableFunction<Throwable, Boolean> dlqFilter) {
+    this.fn = fn;
+    this.mainOutputTag = mainOutputTag;
+    this.additionalOutputTags = additionalOutputTags;
+    this.sideInputs = sideInputs;
+    this.dlqSink = dlqSink;
+    this.dlqFilter = dlqFilter;
+  }
+
+  @Override
+  public DoFn<InputT, ?> getFn() {
+    return fn;
+  }
+
+  @Override
+  public TupleTag<?> getMainOutputTag() {
+    return mainOutputTag;
+  }
+
+  @Override
+  public TupleTagList getAdditionalOutputTags() {
+    return additionalOutputTags;
+  }
+
+  @Override
+  public Map<String, PCollectionView<?>> getSideInputs() {
+    return sideInputs;
+  }
+
+  @Override
+  public DlqSink<InputT> getDlqSink() {
+    return dlqSink;
+  }
+
+  @Override
+  @Nullable
+  public SerializableFunction<Throwable, Boolean> getDlqFilter() {
+    return dlqFilter;
+  }
+
+  @Override
+  public void validate(@Nullable PipelineOptions options) {
+    if (options == null) {
+      return;
+    }
+    Preconditions.checkState(
+        ALLOWED_RUNNERS.contains(options.getRunner().getName()),
+        "ParDoWithDlqMultiOutput is not supported in runner: %s",
+        options.getRunner().getName());
+  }
+
+  /**
+   * Constructs a {@link PCollectionTuple} with one primitive output per tag (main + additional),
+   * matching {@link ParDo.MultiOutput#expand}.
+   *
+   * <p>Sets coders on each output via the {@code CoderRegistry} (same logic as
+   * {@code ParDo.MultiOutput.expand}) so that wrapping a {@code ParDo.MultiOutput} with
+   * {@code .withDlq(...)} does not erase coder inference — anonymous-class DoFns continue to
+   * have their output types resolved automatically.
+   */
+  @Override
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public PCollectionTuple expand(PCollection<? extends InputT> input) {
+    PCollectionTuple outputs =
+        PCollectionTuple.ofPrimitiveOutputsInternal(
+            input.getPipeline(),
+            TupleTagList.of(mainOutputTag).and(additionalOutputTags.getAll()),
+            Collections.emptyMap(),
+            input.getWindowingStrategy(),
+            input.isBounded());
+    CoderRegistry coderRegistry = input.getPipeline().getCoderRegistry();
+    Coder<InputT> inputCoder = ((PCollection<InputT>) input).getCoder();
+    for (PCollection<?> out : outputs.getAll().values()) {
+      try {
+        out.setCoder(
+            (Coder)
+                coderRegistry.getCoder(
+                    out.getTypeDescriptor(), fn.getInputTypeDescriptor(), inputCoder));
+      } catch (CannotProvideCoderException e) {
+        // Leave coder unset for this tag — caller can .setCoder explicitly. Matches
+        // ParDo.MultiOutput's expand behavior.
+      }
+    }
+    return outputs;
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlqMultiOutputSpec.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDoWithDlqMultiOutputSpec.java
@@ -1,0 +1,68 @@
+package org.apache.beam.sdk.transforms;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TupleTagList;
+
+/**
+ * Public accessor interface for the package-private {@link ParDoWithDlqMultiOutput} transform.
+ *
+ * <p>Multi-output counterpart to {@link ParDoWithDlqSpec}. Mirrors the relationship between
+ * {@link ParDo.SingleOutput} and {@link ParDo.MultiOutput}: a {@code ParDo.MultiOutput} can be
+ * wrapped with {@code .withDlq(DlqSink)} to route per-element user-code throws to the sink
+ * while still emitting successful elements to each of the configured output tags.
+ *
+ * <p>This interface allows the Flink runner (which lives in a different package) to inspect
+ * transform properties — {@link #getFn()}, {@link #getMainOutputTag()},
+ * {@link #getAdditionalOutputTags()}, {@link #getSideInputs()}, {@link #getDlqSink()},
+ * {@link #getDlqFilter()} — and reference the {@link #URN} constant, without needing to import
+ * the package-private implementation class.
+ *
+ * <p>Callers outside {@code org.apache.beam.sdk.transforms} should interact with this transform
+ * only through {@link ParDo.MultiOutput#withDlq(DlqSink)} and
+ * {@link ParDo.MultiOutput#withDlq(DlqSink, SerializableFunction)}.
+ *
+ * @param <InputT> the input element type
+ */
+public interface ParDoWithDlqMultiOutputSpec<InputT> {
+
+  /** URN used by the Flink runner to identify and translate this transform. */
+  String URN = "beam:transform:li:pardo_with_dlq_multi_output:v1";
+
+  /** Returns the wrapped {@link DoFn}. */
+  DoFn<InputT, ?> getFn();
+
+  /** Returns the main output tag from the wrapped {@code ParDo.MultiOutput}. */
+  TupleTag<?> getMainOutputTag();
+
+  /** Returns the additional output tags from the wrapped {@code ParDo.MultiOutput}. */
+  TupleTagList getAdditionalOutputTags();
+
+  /**
+   * Returns the side inputs threaded through from the wrapped {@code ParDo.MultiOutput} (an
+   * empty map when none were declared).
+   */
+  Map<String, PCollectionView<?>> getSideInputs();
+
+  /** Returns the {@link DlqSink} that receives failed elements. */
+  DlqSink<InputT> getDlqSink();
+
+  /**
+   * Returns the optional filter predicate, or {@code null} if all exceptions are routed to
+   * the DLQ.
+   */
+  @Nullable
+  SerializableFunction<Throwable, Boolean> getDlqFilter();
+
+  /**
+   * Returns the implementation {@link PTransform} class for use in payload translator
+   * registration. Accessible here because this interface is in the same package as the
+   * package-private {@link ParDoWithDlqMultiOutput}.
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  static Class<? extends PTransform<?, ?>> implementationClass() {
+    return (Class<? extends PTransform<?, ?>>) (Class) ParDoWithDlqMultiOutput.class;
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoWithDlqMultiOutputTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoWithDlqMultiOutputTest.java
@@ -7,9 +7,22 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.CrashingRunner;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.PCollectionViews;
+import org.apache.beam.sdk.values.PValue;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,6 +38,12 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class ParDoWithDlqMultiOutputTest implements Serializable {
+
+  // expand()/getAdditionalInputs() are inspected without running, so abandoned-node
+  // enforcement is disabled.
+  @Rule
+  public final transient TestPipeline pipeline =
+      TestPipeline.create().enableAbandonedNodeEnforcement(false);
 
   // ---------------------------------------------------------------------------
   // Test helpers
@@ -194,5 +213,74 @@ public class ParDoWithDlqMultiOutputTest implements Serializable {
     ParDo.of(new PassThroughMultiOutputFn())
         .withOutputTags(mainTag, TupleTagList.empty())
         .withDlq(new CapturingDlqSink<>(), null);
+  }
+
+  // ---------------------------------------------------------------------------
+  // expand() — coder / type-descriptor propagation (the core of this change)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The common idiom: an anonymous multi-output DoFn with a raw main tag. The per-tag coder loop
+   * cannot resolve the raw main tag (no type info), so {@code expand} must fall back to the DoFn's
+   * output {@link org.apache.beam.sdk.values.TypeDescriptor} on the main output (which lets later
+   * coder inference succeed). Typed additional tags get their coder resolved directly in the loop.
+   */
+  @Test
+  public void testExpandResolvesMainTypeDescriptorAndAdditionalTagCoder() {
+    DoFn<Integer, String> fn =
+        new DoFn<Integer, String>() {
+          @ProcessElement
+          public void processElement(@Element Integer in) {}
+        };
+    TupleTag<String> rawMainTag = new TupleTag<>(); // raw → type-erased
+    TupleTag<String> typedSideTag = new TupleTag<String>("side") {}; // type-captured
+
+    PTransform<PCollection<? extends Integer>, PCollectionTuple> transform =
+        ParDo.of(fn)
+            .withOutputTags(rawMainTag, TupleTagList.of(typedSideTag))
+            .withDlq(new CapturingDlqSink<>());
+
+    PCollection<Integer> input = pipeline.apply(Create.of(1, 2, 3));
+    PCollectionTuple outputs = transform.expand(input);
+
+    // Main tag is raw: getCoder() can't be resolved in the loop, but the fallback recovers the
+    // type from the DoFn so downstream inference no longer fails (the bug this PR fixes).
+    assertEquals(TypeDescriptors.strings(), outputs.get(rawMainTag).getTypeDescriptor());
+    // Type-captured additional tag: coder resolved directly by the per-tag loop.
+    assertTrue(outputs.get(typedSideTag).getCoder() instanceof StringUtf8Coder);
+  }
+
+  /**
+   * Side inputs threaded through {@code .withDlq(...)} must be declared via {@code
+   * getAdditionalInputs()} so the runner translates the view-producing subgraph first.
+   */
+  @Test
+  public void testGetAdditionalInputsDeclaresSideInputs() {
+    PCollectionView<Integer> view = pipeline.apply("side", Create.of(1)).apply(View.asSingleton());
+    TupleTag<Integer> mainTag = new TupleTag<Integer>("main") {};
+
+    PTransform<PCollection<? extends Integer>, PCollectionTuple> transform =
+        ParDo.of(new PassThroughMultiOutputFn())
+            .withOutputTags(mainTag, TupleTagList.empty())
+            .withSideInputs(view)
+            .withDlq(new CapturingDlqSink<>());
+
+    Map<TupleTag<?>, PValue> additionalInputs = transform.getAdditionalInputs();
+    assertEquals(
+        PCollectionViews.toAdditionalInputs(Collections.singletonList(view)), additionalInputs);
+  }
+
+  /** {@code .withDlq(...)} is Flink-only; validate() must reject other runners. */
+  @Test(expected = IllegalStateException.class)
+  public void testValidateRejectsNonFlinkRunner() {
+    TupleTag<Integer> mainTag = new TupleTag<Integer>("main") {};
+    PTransform<PCollection<? extends Integer>, PCollectionTuple> transform =
+        ParDo.of(new PassThroughMultiOutputFn())
+            .withOutputTags(mainTag, TupleTagList.empty())
+            .withDlq(new CapturingDlqSink<>());
+
+    PipelineOptions options = PipelineOptionsFactory.create();
+    options.setRunner(CrashingRunner.class);
+    transform.validate(options);
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoWithDlqMultiOutputTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoWithDlqMultiOutputTest.java
@@ -1,0 +1,198 @@
+package org.apache.beam.sdk.transforms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.Serializable;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TupleTagList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link ParDoWithDlqMultiOutput} and the {@link ParDo.MultiOutput#withDlq}
+ * factory methods.
+ *
+ * <p>These tests cover construction, field accessors, and the URN contract. Pipeline execution
+ * tests (which require the Flink runner) live in {@code beam-runner/runtime-flink} alongside the
+ * translator. The DLQ-side contract for {@link FailedRecord} and {@link DlqSink} is exercised by
+ * {@link ParDoWithDlqTest}; this file focuses on the multi-output-specific surface.
+ */
+@RunWith(JUnit4.class)
+public class ParDoWithDlqMultiOutputTest implements Serializable {
+
+  // ---------------------------------------------------------------------------
+  // Test helpers
+  // ---------------------------------------------------------------------------
+
+  /** A trivial multi-output DoFn used as a stand-in for user logic. */
+  static class PassThroughMultiOutputFn extends DoFn<Integer, Integer> {
+    @ProcessElement
+    public void processElement(@Element Integer input, OutputReceiver<Integer> out) {
+      out.output(input);
+    }
+  }
+
+  /** A no-op {@link DlqSink} that records the last written record for assertions. */
+  static class CapturingDlqSink<T> implements DlqSink<T> {
+    FailedRecord<T> lastRecord;
+    int writeCount = 0;
+
+    @Override
+    public void setup(PipelineOptions options) {}
+
+    @Override
+    public void write(FailedRecord<T> record) {
+      lastRecord = record;
+      writeCount++;
+    }
+
+    @Override
+    public void teardown() {}
+  }
+
+  // ---------------------------------------------------------------------------
+  // ParDoWithDlqMultiOutput construction
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testWithDlqReturnedFromMultiOutput() {
+    TupleTag<Integer> mainTag = new TupleTag<Integer>("main") {};
+    CapturingDlqSink<Integer> sink = new CapturingDlqSink<>();
+    assertNotNull(
+        ParDo.of(new PassThroughMultiOutputFn())
+            .withOutputTags(mainTag, TupleTagList.empty())
+            .withDlq(sink));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testGetFnReturnsSameFn() {
+    PassThroughMultiOutputFn fn = new PassThroughMultiOutputFn();
+    TupleTag<Integer> mainTag = new TupleTag<Integer>("main") {};
+    ParDoWithDlqMultiOutputSpec<Integer> transform =
+        (ParDoWithDlqMultiOutputSpec<Integer>) ParDo.of(fn)
+            .withOutputTags(mainTag, TupleTagList.empty())
+            .withDlq(new CapturingDlqSink<>());
+    assertSame(fn, transform.getFn());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testGetMainOutputTagReturnsSameTag() {
+    TupleTag<Integer> mainTag = new TupleTag<Integer>("main") {};
+    ParDoWithDlqMultiOutputSpec<Integer> transform =
+        (ParDoWithDlqMultiOutputSpec<Integer>) ParDo.of(new PassThroughMultiOutputFn())
+            .withOutputTags(mainTag, TupleTagList.empty())
+            .withDlq(new CapturingDlqSink<>());
+    assertSame(mainTag, transform.getMainOutputTag());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testGetAdditionalOutputTagsReturnsSameTags() {
+    TupleTag<Integer> mainTag = new TupleTag<Integer>("main") {};
+    TupleTag<String> sideA = new TupleTag<String>("sideA") {};
+    TupleTag<String> sideB = new TupleTag<String>("sideB") {};
+    TupleTagList additional = TupleTagList.of(sideA).and(sideB);
+    ParDoWithDlqMultiOutputSpec<Integer> transform =
+        (ParDoWithDlqMultiOutputSpec<Integer>) ParDo.of(new PassThroughMultiOutputFn())
+            .withOutputTags(mainTag, additional)
+            .withDlq(new CapturingDlqSink<>());
+    assertEquals(2, transform.getAdditionalOutputTags().size());
+    assertTrue(transform.getAdditionalOutputTags().getAll().contains(sideA));
+    assertTrue(transform.getAdditionalOutputTags().getAll().contains(sideB));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testGetSideInputsIsEmptyByDefault() {
+    TupleTag<Integer> mainTag = new TupleTag<Integer>("main") {};
+    ParDoWithDlqMultiOutputSpec<Integer> transform =
+        (ParDoWithDlqMultiOutputSpec<Integer>) ParDo.of(new PassThroughMultiOutputFn())
+            .withOutputTags(mainTag, TupleTagList.empty())
+            .withDlq(new CapturingDlqSink<>());
+    assertNotNull(transform.getSideInputs());
+    assertTrue(transform.getSideInputs().isEmpty());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testGetDlqSinkReturnsSameSink() {
+    TupleTag<Integer> mainTag = new TupleTag<Integer>("main") {};
+    CapturingDlqSink<Integer> sink = new CapturingDlqSink<>();
+    ParDoWithDlqMultiOutputSpec<Integer> transform =
+        (ParDoWithDlqMultiOutputSpec<Integer>) ParDo.of(new PassThroughMultiOutputFn())
+            .withOutputTags(mainTag, TupleTagList.empty())
+            .withDlq(sink);
+    assertSame(sink, transform.getDlqSink());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testDlqFilterIsNullByDefault() {
+    TupleTag<Integer> mainTag = new TupleTag<Integer>("main") {};
+    ParDoWithDlqMultiOutputSpec<Integer> transform =
+        (ParDoWithDlqMultiOutputSpec<Integer>) ParDo.of(new PassThroughMultiOutputFn())
+            .withOutputTags(mainTag, TupleTagList.empty())
+            .withDlq(new CapturingDlqSink<>());
+    assertNull(transform.getDlqFilter());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testWithDlqFilterSetsFilter() {
+    TupleTag<Integer> mainTag = new TupleTag<Integer>("main") {};
+    SerializableFunction<Throwable, Boolean> filter = t -> t instanceof IllegalArgumentException;
+    ParDoWithDlqMultiOutputSpec<Integer> transform =
+        (ParDoWithDlqMultiOutputSpec<Integer>) ParDo.of(new PassThroughMultiOutputFn())
+            .withOutputTags(mainTag, TupleTagList.empty())
+            .withDlq(new CapturingDlqSink<>(), filter);
+    assertSame(filter, transform.getDlqFilter());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testWithDlqFilterPreservesFnTagsAndSink() {
+    PassThroughMultiOutputFn fn = new PassThroughMultiOutputFn();
+    TupleTag<Integer> mainTag = new TupleTag<Integer>("main") {};
+    TupleTag<String> sideA = new TupleTag<String>("sideA") {};
+    CapturingDlqSink<Integer> sink = new CapturingDlqSink<>();
+    ParDoWithDlqMultiOutputSpec<Integer> transform =
+        (ParDoWithDlqMultiOutputSpec<Integer>) ParDo.of(fn)
+            .withOutputTags(mainTag, TupleTagList.of(sideA))
+            .withDlq(sink, t -> true);
+    assertSame(fn, transform.getFn());
+    assertSame(mainTag, transform.getMainOutputTag());
+    assertEquals(1, transform.getAdditionalOutputTags().size());
+    assertTrue(transform.getAdditionalOutputTags().getAll().contains(sideA));
+    assertSame(sink, transform.getDlqSink());
+  }
+
+  @Test
+  public void testUrnConstant() {
+    assertEquals(
+        "beam:transform:li:pardo_with_dlq_multi_output:v1", ParDoWithDlqMultiOutputSpec.URN);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithDlqRejectsNullSink() {
+    TupleTag<Integer> mainTag = new TupleTag<Integer>("main") {};
+    ParDo.of(new PassThroughMultiOutputFn())
+        .withOutputTags(mainTag, TupleTagList.empty())
+        .withDlq(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithDlqFilterRejectsNullFilter() {
+    TupleTag<Integer> mainTag = new TupleTag<Integer>("main") {};
+    ParDo.of(new PassThroughMultiOutputFn())
+        .withOutputTags(mainTag, TupleTagList.empty())
+        .withDlq(new CapturingDlqSink<>(), null);
+  }
+}


### PR DESCRIPTION
**Please** add a meaningful description for your change here


# Problem & Solution Overview                                          
                                                                         
  Two fixes to the `.withDlq(...)` DLQ API in the LinkedIn fork of OSS Beam.

  ## 1) Fix `ParDoWithDlq.expand()` coder propagation                    

  Today, the wrapping `PTransform` created by `.withDlq` on a `ParDo.SingleOutput` returns a primitive output `PCollection` with a `null` coder:

  ```java                                                                
  return PCollection.createPrimitiveOutputInternal(                      
      input.getPipeline(), input.getWindowingStrategy(), input.isBounded(), null);

  For wraps over anonymous-class DoFns (e.g. ParDo.of(new DoFn<X, Y>() {…})), Beam's plain ParDo.SingleOutput.expand normally reads the generic
  type parameters via reflection on the anonymous class's bytecode and calls setCoder(...) accordingly. But because .withDlq wraps the original
  ParDo in a different PTransform whose own signature is PCollection<? extends InputT> → PCollection<OutputT>, Beam's coder-inference walk lands
  on the wrapping transform's signature instead of the inner DoFn's. The runtime then throws
                                     
  java.lang.IllegalStateException: Unable to return a default Coder for <stage>.out

downstream. Named-class DoFns happen to work today only because their call sites already have an explicit .setCoder(...) chained after .withDlq
   for other reasons.                                                    

  Fix: mirror ParDo.SingleOutput.expand's schema/coder inference in ParDoWithDlq.expand: try the schema registry first, fall back to the coder
  registry with the DoFn's input/output TypeDescriptors and the input PCollection's coder, leave the coder unset only if neither resolves.
  Anonymous-class .withDlq sites now behave identically to plain anonymous-class ParDo.of.
                                                                         
  This was caught downstream by cgp-nearline's CI: 3 test failures in TestFanoutPipeline, TestRepartitionerPipeline, and TestFilteringPipeline
  all stemmed from this missing propagation around the 4 anonymous gate / filter DoFns wrapped with .withDlq.

  2) Add ParDo.MultiOutput.withDlq(...)                                  

  OSS Beam (LinkedIn fork) only exposes .withDlq on ParDo.SingleOutput today. Multi-output ParDos had no first-class DLQ wrap, forcing consumers
  to either refactor multi-output logic into multiple single-output stages or write a runner-only wrapper.

  This PR adds the multi-output counterpart:                  

PCollectionTuple outputs = input.apply(                                
      ParDo.of(new MyMultiOutputDoFn())                                  
           .withOutputTags(mainTag, TupleTagList.of(sideTagA).and(sideTagB))
           .withDlq(myDlqSink));                                         

  New package-private class ParDoWithDlqMultiOutput<InputT> + public-accessor interface ParDoWithDlqMultiOutputSpec<InputT> follow the same
  structure as ParDoWithDlq / ParDoWithDlqSpec. URN beam:transform:li:pardo_with_dlq_multi_output:v1 reserved for the runner-side translator.

  expand() builds the same PCollectionTuple ParDo.MultiOutput.expand would build and runs the same per-tag coder registration logic, so
  multi-output .withDlq sites get coder inference for free.

  What's in this PR                                                      
                                     
  - ParDoWithDlq.java: expand() now derives the output coder/schema (same logic as ParDo.SingleOutput.expand).
  - ParDoWithDlqMultiOutput.java (new, package-private): multi-output implementation extending PTransform<PCollection<? extends InputT>, 
  PCollectionTuple>.                                                     
  - ParDoWithDlqMultiOutputSpec.java (new, public interface): accessor + URN for the Flink runner translator.
  - ParDo.java: two new withDlq(...) methods on ParDo.MultiOutput (no-filter + with-filter variants).
  - Class-level @SuppressWarnings({"nullness","rawtypes"}) on ParDoWithDlqMultiOutput mirroring the existing one on ParDo (TODO
  apache/beam#20497).    

 Testing Done                                                           
                                                                         
  - Local build pass: ./gradlew :sdks:java:core:compileJava — BUILD SUCCESSFUL.
  - cgp-nearline #2449 test failures will be re-verified once beam-runner picks these up.
  - Unit tests for the new expand() coder propagation paths (single + multi) — happy to add as a follow-up commit; want to confirm the approach
  first.

  Follow-ups (out of scope for this PR)

  1. beam-runner translator for the new URN beam:transform:li:pardo_with_dlq_multi_output:v1. Follows the same pattern as the existing
  ParDoWithDlqTranslator. Once that lands, the in-flight LiParDoWithDlqMultiOutput-based beam-runner PR #2335 can be closed.
  2. Re-pin consumer MPs (cgp-nearline / stork-nearline-flink / notifications-impressions / beam-throttler / ctc) to the beam-runner version that
   picks up these fixes. The anonymous-class .withDlq sites currently failing CI in cgp-nearline #2449 should pass without additional
  .setCoder(...) calls.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
