### PR TITLE
Fix DistributionData percentile sketch data race (AIOOBE) and partial-read deserialization bug

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DistributionData.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DistributionData.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 import org.apache.beam.sdk.metrics.DistributionResult;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
@@ -57,6 +58,18 @@ public class DistributionData implements Serializable {
   private long min;
   private long max;
   private transient Optional<UpdateDoublesSketch> sketch;
+
+  /**
+   * Guards all access to the mutable primitive aggregates and the non-thread-safe percentile {@code
+   * sketch}. DataSketches {@code UpdateDoublesSketch} is documented single-threaded, so the writer
+   * (task/mailbox thread, per-record {@link #update}) and the readers (metric extraction via {@link
+   * #percentiles}, accumulator serialization via {@link #writeObject}, and the JobManager merge via
+   * {@link #combine(DistributionData)}) must be mutually exclusive. A {@link ReentrantLock} is used
+   * (rather than {@code synchronized} on a field) because it is {@code final} and {@link
+   * Serializable}: it survives the TM&rarr;JM accumulator round-trip and always deserializes in the
+   * unlocked state, so no {@code transient} re-initialization is required.
+   */
+  private final ReentrantLock lock = new ReentrantLock();
 
   public static final DistributionData EMPTY = create(0, 0, Long.MAX_VALUE, Long.MIN_VALUE);
 
@@ -97,41 +110,83 @@ public class DistributionData implements Serializable {
   }
 
   public DistributionData combine(long value) {
-    return create(sum() + value, count() + 1, Math.min(value, min()), Math.max(value, max()));
+    lock.lock();
+    try {
+      return create(sum + value, count + 1, Math.min(value, min), Math.max(value, max));
+    } finally {
+      lock.unlock();
+    }
   }
 
   public DistributionData combine(long sum, long count, long min, long max) {
-    return create(sum() + sum, count() + count, Math.min(min, min()), Math.max(max, max()));
+    lock.lock();
+    try {
+      return create(
+          this.sum + sum, this.count + count, Math.min(min, this.min), Math.max(max, this.max));
+    } finally {
+      lock.unlock();
+    }
   }
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Getters
 
   public long sum() {
-    return sum;
+    lock.lock();
+    try {
+      return sum;
+    } finally {
+      lock.unlock();
+    }
   }
 
   public long count() {
-    return count;
+    lock.lock();
+    try {
+      return count;
+    } finally {
+      lock.unlock();
+    }
   }
 
   public long min() {
-    return min;
+    lock.lock();
+    try {
+      return min;
+    } finally {
+      lock.unlock();
+    }
   }
 
   public long max() {
-    return max;
+    lock.lock();
+    try {
+      return max;
+    } finally {
+      lock.unlock();
+    }
   }
 
   /** Gets the percentiles and the percentiles values as a map. */
   public Map<Double, Double> percentiles() {
-    if (!sketch.isPresent() || sketch.get().getN() == 0) {
-      // if the sketch is not present or is empty, do not compute the percentile
-      return ImmutableMap.of();
+    final UpdateDoublesSketch snapshot;
+    final double[] quantiles;
+    lock.lock();
+    try {
+      if (!sketch.isPresent() || sketch.get().getN() == 0) {
+        // if the sketch is not present or is empty, do not compute the percentile
+        return ImmutableMap.of();
+      }
+      quantiles = percentiles.stream().mapToDouble(i -> i / 100).toArray();
+      // Cheap copy of the bounded (k=256 -> a few KB) sketch under the lock; the expensive O(n)
+      // getQuantiles then runs on the immutable snapshot with the lock released, so concurrent
+      // update() writers never race the read that sizes the destination array.
+      snapshot = UpdateDoublesSketch.heapify(Memory.wrap(sketch.get().toByteArray()));
+    } finally {
+      lock.unlock();
     }
 
-    double[] quantiles = percentiles.stream().mapToDouble(i -> i / 100).toArray();
-    double[] quantileResults = sketch.get().getQuantiles(quantiles);
+    double[] quantileResults = snapshot.getQuantiles(quantiles);
 
     final ImmutableMap.Builder<Double, Double> resultBuilder = ImmutableMap.builder();
     for (int k = 0; k < quantiles.length; k++) {
@@ -150,43 +205,79 @@ public class DistributionData implements Serializable {
    * @param value value to update the distribution with.
    */
   public void update(long value) {
-    ++count;
-    min = Math.min(min, value);
-    max = Math.max(max, value);
-    sum += value;
-    sketch.ifPresent(currSketch -> currSketch.update(value));
+    lock.lock();
+    try {
+      ++count;
+      min = Math.min(min, value);
+      max = Math.max(max, value);
+      sum += value;
+      sketch.ifPresent(currSketch -> currSketch.update(value));
+    } finally {
+      lock.unlock();
+    }
   }
 
   /** Merges two distributions. */
   public DistributionData combine(DistributionData other) {
-    if (sketch.isPresent()
-        && other.sketch.isPresent()
-        && sketch.get().getN() > 0
-        && other.sketch.get().getN() > 0) {
-      final DoublesUnion union = new DoublesUnionBuilder().build();
-      union.update(sketch.get());
-      union.update(other.sketch.get());
-      sketch = Optional.of(union.getResult());
-    } else if (other.sketch.isPresent() && other.sketch.get().getN() > 0) {
-      sketch = other.sketch;
+    // Snapshot the other instance's state under its own lock first (copying the sketch bytes rather
+    // than aliasing the live sketch), then mutate this instance under this lock. Snapshotting
+    // other-first keeps this deadlock-free even if the merge ever runs off the single-threaded JM
+    // path, and avoids sharing a mutable sketch reference between two DistributionData instances.
+    final Optional<UpdateDoublesSketch> otherSketch;
+    final long otherSum;
+    final long otherCount;
+    final long otherMin;
+    final long otherMax;
+    other.lock.lock();
+    try {
+      otherSum = other.sum;
+      otherCount = other.count;
+      otherMin = other.min;
+      otherMax = other.max;
+      otherSketch =
+          (other.sketch.isPresent() && other.sketch.get().getN() > 0)
+              ? Optional.of(
+                  UpdateDoublesSketch.heapify(Memory.wrap(other.sketch.get().toByteArray())))
+              : Optional.empty();
+    } finally {
+      other.lock.unlock();
     }
-    sum += other.sum;
-    count += other.count;
-    max = Math.max(max, other.max);
-    min = Math.min(min, other.min);
+
+    lock.lock();
+    try {
+      if (sketch.isPresent() && otherSketch.isPresent() && sketch.get().getN() > 0) {
+        final DoublesUnion union = new DoublesUnionBuilder().build();
+        union.update(sketch.get());
+        union.update(otherSketch.get());
+        sketch = Optional.of(union.getResult());
+      } else if (otherSketch.isPresent()) {
+        sketch = otherSketch;
+      }
+      sum += otherSum;
+      count += otherCount;
+      max = Math.max(max, otherMax);
+      min = Math.min(min, otherMin);
+    } finally {
+      lock.unlock();
+    }
     return this;
   }
 
   public DistributionData reset() {
-    this.sum = 0L;
-    this.count = 0L;
-    this.min = Long.MAX_VALUE;
-    this.max = Long.MIN_VALUE;
-    if (!this.percentiles.isEmpty()) {
-      final DoublesSketchBuilder doublesSketchBuilder = new DoublesSketchBuilder();
-      this.sketch = Optional.of(doublesSketchBuilder.setK(SKETCH_SUMMARY_SIZE).build());
-    } else {
-      this.sketch = Optional.empty();
+    lock.lock();
+    try {
+      this.sum = 0L;
+      this.count = 0L;
+      this.min = Long.MAX_VALUE;
+      this.max = Long.MIN_VALUE;
+      if (!this.percentiles.isEmpty()) {
+        final DoublesSketchBuilder doublesSketchBuilder = new DoublesSketchBuilder();
+        this.sketch = Optional.of(doublesSketchBuilder.setK(SKETCH_SUMMARY_SIZE).build());
+      } else {
+        this.sketch = Optional.empty();
+      }
+    } finally {
+      lock.unlock();
     }
     return this;
   }
@@ -235,11 +326,18 @@ public class DistributionData implements Serializable {
   }
 
   private void writeObject(ObjectOutputStream out) throws IOException {
-    out.defaultWriteObject();
-    if (sketch.isPresent()) {
-      byte[] bytes = sketch.get().toByteArray();
-      out.writeInt(bytes.length);
-      out.write(bytes);
+    // Serializing the accumulator (TM->JM) is a cross-thread reader of the sketch that races the
+    // task thread's update(); guard it so it cannot observe the sketch mid-mutation.
+    lock.lock();
+    try {
+      out.defaultWriteObject();
+      if (sketch.isPresent()) {
+        byte[] bytes = sketch.get().toByteArray();
+        out.writeInt(bytes.length);
+        out.write(bytes);
+      }
+    } finally {
+      lock.unlock();
     }
   }
 
@@ -249,7 +347,9 @@ public class DistributionData implements Serializable {
     if (!this.percentiles.isEmpty()) {
       int len = in.readInt();
       byte[] bytes = new byte[len];
-      in.read(bytes);
+      // readFully (not read) guarantees the whole sketch image is read; a plain read() may return
+      // fewer bytes when the array spans the stream buffer, corrupting the deserialized sketch.
+      in.readFully(bytes);
       this.sketch = Optional.of(UpdateDoublesSketch.heapify(Memory.wrap(bytes)));
     } else {
       this.sketch = Optional.empty();

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/DistributionDataTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/DistributionDataTest.java
@@ -18,7 +18,23 @@
 package org.apache.beam.runners.core.metrics;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.beam.sdk.util.SerializableUtils;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,6 +42,8 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link DistributionData}. */
 @RunWith(JUnit4.class)
 public class DistributionDataTest {
+  private static final Set<Double> PERCENTILES = ImmutableSet.of(50.0, 90.0, 99.0);
+
   @Test
   public void testSingleton() {
     DistributionData data = DistributionData.singleton(5);
@@ -63,5 +81,163 @@ public class DistributionDataTest {
     assertEquals(2, data.count());
     assertEquals(1, data.min());
     assertEquals(4, data.max());
+  }
+
+  @Test
+  public void testPercentilesEmptySketch() {
+    // No data added -> percentiles must be empty, and combine skips the union (unchanged behavior).
+    DistributionData data = DistributionData.withPercentiles(PERCENTILES);
+    assertTrue(data.percentiles().isEmpty());
+
+    DistributionData other = DistributionData.withPercentiles(PERCENTILES);
+    assertTrue(data.combine(other).percentiles().isEmpty());
+  }
+
+  @Test
+  public void testPercentilesPopulated() {
+    DistributionData data = DistributionData.withPercentiles(PERCENTILES);
+    for (long i = 1; i <= 1000; i++) {
+      data.update(i);
+    }
+    assertEquals(1000, data.count());
+    assertEquals(1, data.min());
+    assertEquals(1000, data.max());
+
+    Map<Double, Double> percentiles = data.percentiles();
+    assertEquals(PERCENTILES.size(), percentiles.size());
+    // Percentiles must be monotonically non-decreasing and within the observed value range.
+    assertTrue(percentiles.get(50.0) <= percentiles.get(90.0));
+    assertTrue(percentiles.get(90.0) <= percentiles.get(99.0));
+    assertTrue(percentiles.get(50.0) >= 1.0 && percentiles.get(99.0) <= 1000.0);
+  }
+
+  @Test
+  public void testSerializationRoundTripPreservesState() {
+    DistributionData data = DistributionData.withPercentiles(PERCENTILES);
+    for (long i = 1; i <= 500; i++) {
+      data.update(i);
+    }
+
+    DistributionData restored =
+        (DistributionData)
+            SerializableUtils.deserializeFromByteArray(
+                SerializableUtils.serializeToByteArray(data), "DistributionData");
+
+    assertEquals(data.sum(), restored.sum());
+    assertEquals(data.count(), restored.count());
+    assertEquals(data.min(), restored.min());
+    assertEquals(data.max(), restored.max());
+    assertEquals(data.percentiles(), restored.percentiles());
+  }
+
+  @Test
+  public void testCombineWithPercentilesMerges() {
+    DistributionData left = DistributionData.withPercentiles(PERCENTILES);
+    DistributionData right = DistributionData.withPercentiles(PERCENTILES);
+    for (long i = 1; i <= 500; i++) {
+      left.update(i);
+    }
+    for (long i = 501; i <= 1000; i++) {
+      right.update(i);
+    }
+
+    left.combine(right);
+    assertEquals(1000, left.count());
+    assertEquals(1, left.min());
+    assertEquals(1000, left.max());
+    // The merged sketch spans both halves.
+    Map<Double, Double> percentiles = left.percentiles();
+    assertTrue(percentiles.get(50.0) <= percentiles.get(99.0));
+    assertTrue(percentiles.get(99.0) <= 1000.0);
+    // Combining does not mutate the other instance.
+    assertEquals(500, right.count());
+  }
+
+  /**
+   * Regression guard for the {@code DistributionData} sketch race: concurrent writers ({@link
+   * DistributionData#update}) racing readers ({@link DistributionData#percentiles} / {@link
+   * DistributionData#extractResult}) and accumulator serialization ({@code writeObject}) previously
+   * threw {@code ArrayIndexOutOfBoundsException} from {@code getQuantiles}. With the
+   * snapshot-under-lock fix, no exception should be thrown.
+   */
+  @Test
+  public void testConcurrentAccessDoesNotThrow() throws InterruptedException, ExecutionException {
+    final int writerCount = 4;
+    final int readerCount = 2;
+    final int serializerCount = 2;
+    final long durationMillis = 3000;
+
+    final DistributionData data = DistributionData.withPercentiles(PERCENTILES);
+    // Seed so the sketch is non-empty before readers start.
+    for (long i = 1; i <= 256; i++) {
+      data.update(i);
+    }
+
+    final ExecutorService executor =
+        Executors.newFixedThreadPool(writerCount + readerCount + serializerCount);
+    final AtomicBoolean stop = new AtomicBoolean(false);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final CountDownLatch started = new CountDownLatch(writerCount + readerCount + serializerCount);
+
+    final ImmutableList.Builder<Runnable> tasksBuilder = ImmutableList.builder();
+    for (int w = 0; w < writerCount; w++) {
+      tasksBuilder.add(
+          () -> {
+            started.countDown();
+            long v = 0;
+            while (!stop.get() && failure.get() == null) {
+              data.update(v++);
+            }
+          });
+    }
+    for (int r = 0; r < readerCount; r++) {
+      tasksBuilder.add(
+          () -> {
+            started.countDown();
+            while (!stop.get() && failure.get() == null) {
+              data.percentiles();
+              data.extractResult();
+            }
+          });
+    }
+    for (int s = 0; s < serializerCount; s++) {
+      tasksBuilder.add(
+          () -> {
+            started.countDown();
+            while (!stop.get() && failure.get() == null) {
+              SerializableUtils.deserializeFromByteArray(
+                  SerializableUtils.serializeToByteArray(data), "DistributionData");
+            }
+          });
+    }
+
+    final List<Runnable> tasks = tasksBuilder.build();
+    final List<Future<?>> futures = new ArrayList<>();
+    for (Runnable task : tasks) {
+      futures.add(
+          executor.submit(
+              () -> {
+                try {
+                  task.run();
+                } catch (Throwable t) {
+                  failure.compareAndSet(null, t);
+                }
+              }));
+    }
+
+    started.await(10, TimeUnit.SECONDS);
+    Thread.sleep(durationMillis);
+    stop.set(true);
+    executor.shutdown();
+    assertTrue("Threads did not finish", executor.awaitTermination(30, TimeUnit.SECONDS));
+
+    // Drain futures so no submitted task's completion is silently ignored.
+    for (Future<?> future : futures) {
+      future.get();
+    }
+
+    if (failure.get() != null) {
+      throw new AssertionError("Concurrent access threw an exception", failure.get());
+    }
   }
 }


### PR DESCRIPTION
## Summary

`DistributionData` (LI Beam fork) holds a single **mutable, non-thread-safe** DataSketches `UpdateDoublesSketch` and mutated it **in place with no synchronization**. The per-record writer (`DistributionCell.update` on the task/mailbox thread) races concurrent readers:

- `percentiles()` / `extractResult()` during metric extraction (the AIOOBE site),
- `writeObject()` during accumulator serialization (TM→JM),
- `combine(DistributionData)` during JobManager accumulator merge.

A read (`getQuantiles`, which sizes a destination array from `getN()` then copies) concurrent with a write (`update`, which grows the sketch) overruns the array and throws:

```
java.lang.ArrayIndexOutOfBoundsException: Index N out of bounds for length N
    at org.apache.datasketches.quantiles.DoublesAuxiliary.populateFromDoublesSketch(...)
    at org.apache.datasketches.quantiles.DoublesSketch.getQuantiles(...)
```

DataSketches `UpdateDoublesSketch` is documented single-threaded, so this is a caller-side concurrency bug, independent of the datasketches version.

## Fix — snapshot-under-lock

- Add a `private final ReentrantLock lock` guarding all sketch/primitive access. `ReentrantLock` (rather than `synchronized` on a field) is used because it is `final` + `Serializable`: it survives the TM→JM accumulator round-trip and always deserializes unlocked, so no `transient` re-init is needed. (Also satisfies ErrorProne `SynchronizeOnNonFinalField` under `-Werror`.)
- **Writers guarded** (O(1)/O(sketch)): `update`, `combine(long)`, `combine(long,long,long,long)`, `combine(DistributionData)`, `reset`.
- **Reader `percentiles()`**: copies the bounded (k=256) sketch under the lock, then runs the expensive O(n) `getQuantiles` on the immutable snapshot **outside** the lock — so per-record writers never block on the quantile computation.
- **`combine(DistributionData)`**: snapshots `other` under its own lock first (copying sketch bytes, not aliasing) → deadlock-free, no shared mutable sketch.
- **`writeObject` guarded**; `sum/count/min/max` getters guarded for consistent snapshots.

## Additional fix (tightly coupled)

`readObject` used `InputStream.read(byte[])` (reads *up to* `len` bytes), which returned a **partial** sketch image when the array spanned the stream buffer — corrupting the deserialized sketch and yielding wrong percentiles after the TM→JM transfer. Switched to `readFully`. This was caught by the new serialization parity test.

## Testing

- **Concurrency stress test** (writers + readers + serializers): reproduces the exact `ArrayIndexOutOfBoundsException` (`DoublesAuxiliary.populateFromDoublesSketch` → `getQuantiles`) on the **pre-fix** code and **passes** with the fix — the regression guard.
- Serialization round-trip + populated/empty percentile + `combine` parity tests.
- All 8 `DistributionDataTest` tests pass; Spotless/ErrorProne clean. Pre-existing unrelated failures in `DistributionCellTest`/`MetricsContainerImplTest` were confirmed present on the untouched baseline.

## Performance

Write path adds one uncontended monitor acquire (nanoseconds, lock-elidable). Read/serialize path holds the lock only for a bounded few-KB `toByteArray()` copy, not the O(n) `getQuantiles`. No measurable throughput regression expected — the fix removes a crash, not adds a bottleneck.
